### PR TITLE
Fix build with SLEEP_ENABLED

### DIFF
--- a/matter/wifi/wf200/host_if.cpp
+++ b/matter/wifi/wf200/host_if.cpp
@@ -481,7 +481,7 @@ wfx_events_task(void * p_arg)
             if (!(wfx_get_wifi_state() & SL_WFX_AP_INTERFACE_UP))
             {
                 // Enable the power save
-                sl_wfx_set_power_mode(WFM_PM_MODE_PS, 1);
+                sl_wfx_set_power_mode(WFM_PM_MODE_PS, WFM_PM_POLL_UAPSD, 1);
                 sl_wfx_enable_device_power_save();
             }
 #endif


### PR DESCRIPTION
This fixes building the EFR32 examples of `lock-app` and `lighting-app` from https://github.com/project-chip/connectedhomeip/ when passing the `--sed` parameter to the build script.