### PR TITLE
Bugfix/mg24 rs91x spi

### DIFF
--- a/matter/wifi/rs911x/hal/efx_spi_intf.c
+++ b/matter/wifi/rs911x/hal/efx_spi_intf.c
@@ -139,14 +139,19 @@ void sl_wfx_host_init_bus(void)
   GPIO->EUSARTROUTE[1].ROUTEEN = GPIO_EUSART_ROUTEEN_RXPEN |    // MISO
                                  GPIO_EUSART_ROUTEEN_TXPEN |    // MOSI
                                  GPIO_EUSART_ROUTEEN_SCLKPEN;
-     //Allow RS916
-   GPIO_PinModeSet(gpioPortC, 0, gpioModePushPull, 0);
-   //Disable flash
-   GPIO_PinModeSet(gpioPortC, 4, gpioModePushPull, 1);
-   //Disable Display
-   GPIO_PinModeSet(gpioPortC, 8, gpioModePushPull, 1);
-   //Disable Display Enable
-   GPIO_PinModeSet(gpioPortC, 9, gpioModePushPull, 0);
+  /*For MG24 DISPLAY,FLASH & RS9116 communication uses same SPI line which
+   * causes RS9116 communication interruption randomly. Below changes resolve 
+   * this issue. Once proper fix is given to multiplex all the features on SPI line, 
+   * these changes can be removed
+   */
+  //Enable RS916 communication
+  GPIO_PinModeSet(gpioPortC, 0, gpioModePushPull, 0);
+  //Disable flash
+  GPIO_PinModeSet(gpioPortC, 4, gpioModePushPull, 1);
+  //Disable Display
+  GPIO_PinModeSet(gpioPortC, 8, gpioModePushPull, 1);
+  //Disable Display Enable
+  GPIO_PinModeSet(gpioPortC, 9, gpioModePushPull, 0);
   // Configure and enable EUSART1
   EUSART_SpiInit(EUSART1, &init);
 

--- a/matter/wifi/rs911x/hal/efx_spi_intf.c
+++ b/matter/wifi/rs911x/hal/efx_spi_intf.c
@@ -100,7 +100,7 @@ void sl_wfx_host_init_bus(void)
   // Default asynchronous initializer (main/master mode and 8-bit data)
   EUSART_SpiInit_TypeDef init = EUSART_SPI_MASTER_INIT_DEFAULT_HF;
 
-  init.bitRate = 12000000;         // 10 MHz shift clock
+  init.bitRate = 12000000;         // 12 MHz shift clock
   init.advancedSettings = &adv;   // Advanced settings structure
 #endif
 #if defined(EFR32MG12)
@@ -139,7 +139,14 @@ void sl_wfx_host_init_bus(void)
   GPIO->EUSARTROUTE[1].ROUTEEN = GPIO_EUSART_ROUTEEN_RXPEN |    // MISO
                                  GPIO_EUSART_ROUTEEN_TXPEN |    // MOSI
                                  GPIO_EUSART_ROUTEEN_SCLKPEN;
-
+     //Allow RS916
+   GPIO_PinModeSet(gpioPortC, 0, gpioModePushPull, 0);
+   //Disable flash
+   GPIO_PinModeSet(gpioPortC, 4, gpioModePushPull, 1);
+   //Disable Display
+   GPIO_PinModeSet(gpioPortC, 8, gpioModePushPull, 1);
+   //Disable Display Enable
+   GPIO_PinModeSet(gpioPortC, 9, gpioModePushPull, 0);
   // Configure and enable EUSART1
   EUSART_SpiInit(EUSART1, &init);
 


### PR DESCRIPTION
#### Problem / Feature
What is being fixed? What is the feature being added? Examples:
Added fix for mg24+Rs9116 spi issue

#### Change overview
What's in this PR
For MG24 DISPLAY,FLASH & RS9116 communication uses same SPI line which causes RS9116 communication interruption randomly. Below changes resolve this issue. Once proper fix is given to multiplex all the features on SPI line, these changes can be removed
Below changes disable display & external flash, hence need to use internal flash boot loader until permanent fix is given
#### Testing
How was this tested?
Tested manually using EFR32+RS9116