### PR TITLE
Added disconnection support from connected AP in RS911x and WF200

### DIFF
--- a/matter/wifi/rs911x/rsi_if.c
+++ b/matter/wifi/rs911x/rsi_if.c
@@ -99,6 +99,10 @@ int32_t wfx_rsi_reset_count()
   }
   return status;
 }
+int32_t wfx_rsi_disconnect(){
+	int32_t status = rsi_wlan_disconnect();
+	return status;
+}
 static void wfx_rsi_join_cb(uint16_t status, const uint8_t *buf, const uint16_t len)
 {
   WFX_RSI_LOG("%s: status: %02x", __func__, status);

--- a/matter/wifi/rs911x/wfx_rsi.h
+++ b/matter/wifi/rs911x/wfx_rsi.h
@@ -68,6 +68,7 @@ void wfx_ip_changed_notify(int got_ip);
 int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t *ap);
 int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t *extra_info);
 int32_t wfx_rsi_reset_count();
+int32_t wfx_rsi_disconnect();
 #define WFX_RSI_LOG(...) efr32Log(__VA_ARGS__);
 
 #ifdef __cplusplus

--- a/matter/wifi/rs911x/wfx_rsi_host.c
+++ b/matter/wifi/rs911x/wfx_rsi_host.c
@@ -157,9 +157,11 @@ wifi_mode_t wfx_get_wifi_mode()
 sl_status_t wfx_sta_discon(void)
 {
   WFX_RSI_LOG("%s: started.", __func__);
-  /* TODO - Disconnect station mode from connected AP */
+  int32_t status;
+  status = wfx_rsi_disconnect();
+  wfx_rsi.dev_state &= ~WFX_RSI_ST_STA_CONNECTED;
   WFX_RSI_LOG("%s: completed.", __func__);
-  return SL_STATUS_OK;
+  return status;
 }
 bool wfx_have_ipv4_addr(sl_wfx_interface_t which_if)
 {

--- a/matter/wifi/wf200/host_if.cpp
+++ b/matter/wifi/wf200/host_if.cpp
@@ -866,10 +866,11 @@ wfx_have_ipv6_addr (sl_wfx_interface_t which_if)
 
 sl_status_t wfx_sta_discon(void)
 {
-  EFR32_LOG("STA-Discon: TODO");
-  /* TODO - Disconnect station mode from connected AP */
-
-  return SL_STATUS_OK;
+  EFR32_LOG("STA-Disconnecting");
+  int32_t status = sl_wfx_send_disconnect_command();
+  wifi_extra &= ~WE_ST_STA_CONN;
+  xEventGroupSetBits(sl_wfx_event_group, SL_WFX_RETRY_CONNECT);
+  return status;
 }
 bool wfx_is_sta_mode_enabled(void)
 {


### PR DESCRIPTION
#### Problem / Feature
The disconnection from connected AP was not present in RS911x and WF200

#### Change overview
Added support to disconnect node from a connected AP.

#### Testing
Tested manually using MG12+RS911x and MG12+WF200