### PR TITLE
Hal board init Function refactoring

### DIFF
--- a/matter/wifi/rs911x/hal/efx_spi_intf.c
+++ b/matter/wifi/rs911x/hal/efx_spi_intf.c
@@ -63,6 +63,16 @@ static void dma_init(void)
 /****************************************************************************
  * Initialize SPI peripheral
  *****************************************************************************/
+void rsi_sem_init(void)
+{
+  spi_sem = xSemaphoreCreateBinary();
+  xSemaphoreGive(spi_sem);
+  dma_init();
+}
+
+/****************************************************************************
+ * Initialize host bus
+ *****************************************************************************/
 void sl_wfx_host_init_bus(void)
 {
   // Initialize and enable the USART
@@ -153,6 +163,9 @@ void sl_wfx_host_init_bus(void)
  */
 void sl_wfx_host_gpio_init(void)
 {
+  /* Semaphore and dma init */
+  rsi_sem_init();
+
 #if defined(EFR32MG24)
   sl_device_init_hfxo();
   sl_device_init_dpll();
@@ -193,19 +206,6 @@ void sl_wfx_host_reset_chip(void)
 
   // Delay for 3ms
   vTaskDelay(pdMS_TO_TICKS(3));
-}
-void rsi_hal_board_init(void)
-{
-  spi_sem = xSemaphoreCreateBinary();
-  xSemaphoreGive(spi_sem);
-  WFX_RSI_LOG("RSI_HAL: init GPIO");
-  sl_wfx_host_gpio_init();
-  WFX_RSI_LOG("RSI_HAL: init SPI");
-  sl_wfx_host_init_bus();
-  dma_init();
-  WFX_RSI_LOG("RSI_HAL: Reset Wifi");
-  sl_wfx_host_reset_chip ();
-  WFX_RSI_LOG("RSI_HAL: Init done");
 }
 
 static bool rx_dma_complete(unsigned int channel, unsigned int sequenceNo, void *userParam)

--- a/matter/wifi/wf200/efr_spi.c
+++ b/matter/wifi/wf200/efr_spi.c
@@ -77,7 +77,7 @@ uint8_t wirq_irq_nb = SL_WFX_HOST_PINOUT_SPI_IRQ; // SL_WFX_HOST_PINOUT_SPI_WIRQ
 /****************************************************************************
  * Initialize SPI peripheral
  *****************************************************************************/
-sl_status_t sl_wfx_host_init_bus(void)
+void sl_wfx_host_init_bus(void)
 {
   // Initialize and enable the USART
   USART_InitSync_TypeDef usartInit = USART_INITSYNC_DEFAULT;
@@ -145,8 +145,6 @@ sl_status_t sl_wfx_host_init_bus(void)
   DMADRV_AllocateChannel(&rx_dma_channel, NULL);
   GPIO_PinModeSet(SL_WFX_HOST_PINOUT_SPI_CS_PORT, SL_WFX_HOST_PINOUT_SPI_CS_PIN, gpioModePushPull, 1);
   MY_USART->CMD = USART_CMD_CLEARRX | USART_CMD_CLEARTX;
-
-  return SL_STATUS_OK;
 }
 
 /****************************************************************************

--- a/matter/wifi/wf200/host_if.cpp
+++ b/matter/wifi/wf200/host_if.cpp
@@ -687,7 +687,6 @@ static void wfx_wifi_hw_start(void)
   EFR32_LOG("STARTING WF200\n");
   wifi_extra |= WE_ST_HW_STARTED;
 
-  sl_wfx_host_gpio_init();
   if ((status = wfx_init()) == SL_STATUS_OK) {
     /* Initialize the LwIP stack */
     EFR32_LOG("WF200:Start LWIP");

--- a/matter/wifi/wf200/wf200_init.c
+++ b/matter/wifi/wf200/wf200_init.c
@@ -229,7 +229,7 @@ sl_status_t sl_wfx_host_set_wake_up_pin(uint8_t state)
   return SL_STATUS_OK;
 }
 
-sl_status_t sl_wfx_host_reset_chip(void)
+void  sl_wfx_host_reset_chip(void)
 {
   // Pull it low for at least 1 ms to issue a reset sequence
   GPIO_PinOutClear(SL_WFX_HOST_PINOUT_RESET_PORT, SL_WFX_HOST_PINOUT_RESET_PIN);
@@ -244,7 +244,6 @@ sl_status_t sl_wfx_host_reset_chip(void)
   vTaskDelay(pdMS_TO_TICKS(3));
 
   host_context.wf200_initialized = 0;
-  return SL_STATUS_OK;
 }
 
 sl_status_t sl_wfx_host_wait_for_wake_up(void)

--- a/matter/wifi/wfx_host_events.h
+++ b/matter/wifi/wfx_host_events.h
@@ -52,7 +52,6 @@
 #define SL_WFX_DISCONNECT_IND_ID 3
 #define SL_WFX_SCAN_COMPLETE_ID 4
 #define WFX_RSI_SSID_SIZE 64
-
 #endif /* WF200 */
 
 #ifndef RS911X_SOCKETS
@@ -71,7 +70,6 @@
 #define SL_WFX_SCAN_START (1 << 5)
 #define SL_WFX_SCAN_COMPLETE (1 << 6)
 #define SL_WFX_RETRY_CONNECT (1 << 7)
-
 #endif /* RS911X_SOCKETS */
 
 #include "sl_status.h"
@@ -156,11 +154,15 @@ typedef enum {
 } sl_wfx_interface_t;
 
 #endif /* RS911X_WIFI */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void sl_wfx_host_gpio_init(void);
+void sl_wfx_host_init_bus(void);
+void sl_wfx_host_reset_chip(void);
+
 sl_status_t wfx_wifi_start(void);
 void wfx_enable_sta_mode(void);
 sl_wfx_state_t wfx_get_wifi_state(void);


### PR DESCRIPTION
What is being fixed? Examples:
Platform init functions refactoring

Change overview
What's in this PR
- platform init related function are moved to EFR platform init file.
- Remove Hal board init function from the wifi interface.

Testing
How was this tested? (at least one bullet point required)
basic test cases run manually on mg12+rs9116 and wf200 also