### PR TITLE
HAL board init function refactoring

### DIFF
--- a/matter/wifi/rs911x/hal/efx_spi_intf.c
+++ b/matter/wifi/rs911x/hal/efx_spi_intf.c
@@ -196,16 +196,25 @@ void sl_wfx_host_reset_chip(void)
 }
 void rsi_hal_board_init(void)
 {
-  spi_sem = xSemaphoreCreateBinary();
-  xSemaphoreGive(spi_sem);
-  WFX_RSI_LOG("RSI_HAL: init GPIO");
-  sl_wfx_host_gpio_init();
-  WFX_RSI_LOG("RSI_HAL: init SPI");
-  sl_wfx_host_init_bus();
-  dma_init();
   WFX_RSI_LOG("RSI_HAL: Reset Wifi");
   sl_wfx_host_reset_chip ();
+
   WFX_RSI_LOG("RSI_HAL: Init done");
+}
+
+void wifi_board_init(void)
+{
+  spi_sem = xSemaphoreCreateBinary();
+  xSemaphoreGive(spi_sem);
+
+  WFX_RSI_LOG("Wifi board: init GPIO");
+  sl_wfx_host_gpio_init();
+
+  WFX_RSI_LOG("Wifi board: init SPI");
+  sl_wfx_host_init_bus();
+
+  WFX_RSI_LOG("Wifi board: init DMA");
+  dma_init();
 }
 
 static bool rx_dma_complete(unsigned int channel, unsigned int sequenceNo, void *userParam)

--- a/matter/wifi/wf200/efr_gpio.c
+++ b/matter/wifi/wf200/efr_gpio.c
@@ -42,6 +42,13 @@ static void sl_wfx_spi_wakeup_irq_callback(uint8_t irqNumber)
  *****************************************************************************/
 void sl_wfx_host_gpio_init(void)
 {
+  /* Place holder for a call from gecko SDK code
+   * TODO
+   */
+}
+
+void sl_wf200_host_gpio_init(void)
+{
   EFR32_LOG("WIFI: GPIO Init:IRQ=%d", wirq_irq_nb);
   // Enable GPIO clock.
   CMU_ClockEnable(cmuClock_GPIO, true);

--- a/matter/wifi/wf200/efr_spi.c
+++ b/matter/wifi/wf200/efr_spi.c
@@ -79,6 +79,14 @@ uint8_t wirq_irq_nb = SL_WFX_HOST_PINOUT_SPI_IRQ; // SL_WFX_HOST_PINOUT_SPI_WIRQ
  *****************************************************************************/
 sl_status_t sl_wfx_host_init_bus(void)
 {
+  /* TODO
+   * Place holder for a call from Gecko SDK code
+   */
+  return SL_STATUS_OK;
+}
+
+sl_status_t sl_wf200_host_init_bus(void)
+{
   // Initialize and enable the USART
   USART_InitSync_TypeDef usartInit = USART_INITSYNC_DEFAULT;
 

--- a/matter/wifi/wf200/sl_wfx_host.h
+++ b/matter/wifi/wf200/sl_wfx_host.h
@@ -66,3 +66,5 @@ typedef struct __attribute__((__packed__)) scan_result_list_s {
 
 void sl_wfx_host_start_platform_interrupt(void);
 extern SemaphoreHandle_t wfx_wakeup_sem;
+void sl_wf200_host_gpio_init(void);
+sl_status_t sl_wf200_host_init_bus(void);

--- a/matter/wifi/wf200/wf200_init.c
+++ b/matter/wifi/wf200/wf200_init.c
@@ -121,6 +121,15 @@ sl_status_t sl_wfx_host_init(void)
   return SL_STATUS_OK;
 }
 
+void wifi_board_init(void)
+{
+  //WFX: Host gpio Init
+  sl_wf200_host_gpio_init();
+
+  //WFX: Host SPI bus Init
+  sl_wf200_host_init_bus();
+}
+
 /****************************************************************************
  * Get firmware data
  *****************************************************************************/


### PR DESCRIPTION
#### Problem
Platform init refactoring.

#### Change overview
We changed the GPIO and Bus init functions, now both these functions are called from
init_efr_platform().

#### Testing
How was this tested? (at least one bullet point required)

- Tested on HW ( MG12 + RS9116 & MG12 + WF200 )
- Commissioning 20 times.
- Sanity TC's