### PR TITLE
Align brd2703a event_handler file with the other mg24 boards. 

### DIFF
--- a/matter/efr32/efr32mg24/BRD2703A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg24/BRD2703A/autogen/sl_event_handler.c
@@ -1,106 +1,82 @@
+#include "sl_event_handler.h"
+
+#include "cmsis_os2.h"
 #include "em_chip.h"
-#include "sl_device_init_nvic.h"
+#include "gpiointerrupt.h"
+#include "pa_conversions_efr32.h"
+#include "sl_board_control.h"
 #include "sl_board_init.h"
+#include "sl_device_init_clocks.h"
 #include "sl_device_init_dcdc.h"
-#include "sl_hfxo_manager.h"
+#include "sl_device_init_dpll.h"
+#include "sl_device_init_emu.h"
 #include "sl_device_init_hfxo.h"
 #include "sl_device_init_lfrco.h"
 #include "sl_device_init_lfxo.h"
-#include "sl_device_init_clocks.h"
-#include "sl_device_init_emu.h"
-#include "pa_conversions_efr32.h"
+#include "sl_device_init_nvic.h"
+#include "sl_hfxo_manager.h"
 #include "sl_rail_util_pti.h"
-#include "btl_interface.h"
-#include "sl_board_control.h"
-#include "sl_bt_rtos_adaptation.h"
-#include "sl_sleeptimer.h"
-#include "gpiointerrupt.h"
-#include "sl_mbedtls.h"
-#include "sl_mpu.h"
-#include "nvm3_default.h"
 #include "sl_simple_button_instances.h"
 #include "sl_simple_led_instances.h"
-#include "sl_device_init_dpll.h"
-
+#include "sl_sleeptimer.h"
 #if defined(CONFIG_ENABLE_UART)
 #include "sl_uartdrv_instances.h"
-#include "psa/crypto.h"
-#include "sli_protocol_crypto.h"
-#include "cmsis_os2.h"
-#include "sl_bluetooth.h"
+#endif // CONFIG_ENABLE_UART
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
 #include "sl_power_manager.h"
 #endif
 
 void sl_platform_init(void)
 {
-  CHIP_Init();
-  sl_device_init_nvic();
-  sl_board_preinit();
-  sl_device_init_dcdc();
-  sl_hfxo_manager_init_hardware();
-  sl_device_init_hfxo();
-  sl_device_init_lfrco();
-  sl_device_init_lfxo();
-  sl_device_init_dpll();
-  sl_device_init_clocks();
-  sl_device_init_emu();
-  sl_board_init();
-  bootloader_init();
-  nvm3_initDefault();
-  osKernelInitialize();
+    CHIP_Init();
+    sl_device_init_nvic();
+    sl_board_preinit();
+    sl_device_init_dcdc();
+    sl_hfxo_manager_init_hardware();
+    sl_device_init_hfxo();
+    sl_device_init_lfrco();
+    sl_device_init_lfxo();
+    sl_device_init_dpll();
+    sl_device_init_clocks();
+    sl_device_init_emu();
+    sl_board_init();
+    osKernelInitialize();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
-  sl_power_manager_init();
+    sl_power_manager_init();
 #endif
 }
 
-void sl_kernel_start(void)
-{
-  osKernelStart();
-}
+void sl_kernel_start(void) { osKernelStart(); }
 
 void sl_driver_init(void)
 {
-  GPIOINT_Init();
-  sl_simple_button_init_instances();
-  sl_simple_led_init_instances();
+    GPIOINT_Init();
+    sl_simple_button_init_instances();
+    sl_simple_led_init_instances();
 #if defined(CONFIG_ENABLE_UART)
-  sl_uartdrv_init_instances();
+    sl_uartdrv_init_instances();
 #endif // CONFIG_ENABLE_UART
 }
 
 void sl_service_init(void)
 {
-  sl_board_configure_vcom();
-  sl_sleeptimer_init();
-  sl_hfxo_manager_init();
-  sl_mbedtls_init();
-  sl_mpu_disable_execute_from_ram();
-  psa_crypto_init();
-  sli_aes_seed_mask();
+    sl_board_configure_vcom();
+    sl_sleeptimer_init();
+    sl_hfxo_manager_init();
 }
 
 void sl_stack_init(void)
 {
-  sl_rail_util_pa_init();
-  sl_rail_util_pti_init();
+    sl_rail_util_pa_init();
+    sl_rail_util_pti_init();
 }
 
-void sl_internal_app_init(void)
-{
-}
+void sl_internal_app_init(void) { }
 
-void sl_platform_process_action(void)
-{
-}
+void sl_platform_process_action(void) { }
 
-void sl_service_process_action(void)
-{
-}
+void sl_service_process_action(void) { }
 
-void sl_stack_process_action(void)
-{
-}
+void sl_stack_process_action(void) { }
 
-void sl_internal_app_process_action(void)
-{
-}
+void sl_internal_app_process_action(void) { }


### PR DESCRIPTION
#### Problem / Feature
BRD2703a do not build for release or specific build arguments.

#### Change overview
Align includes, init calls, and #ifdefs to match other mg24 boards
Remove unused/untested init calls for now (aka MPU, AES,some bluetooth calls( 

#### Testing
Build apps in release for this board