### PR TITLE
Fix potential LCD spotting on BRD4164A and BRD4187A when lcd screen is disabled

### DIFF
--- a/matter/efr32/efr32mg12/BRD4164A/config/sl_board_control_config.h
+++ b/matter/efr32/efr32mg12/BRD4164A/config/sl_board_control_config.h
@@ -9,7 +9,7 @@
 
 // <q SL_BOARD_ENABLE_DISPLAY> Enable Display
 // <i> Default: 0
-#define SL_BOARD_ENABLE_DISPLAY                 1
+#define SL_BOARD_ENABLE_DISPLAY                 0
 
 // <q SL_BOARD_ENABLE_SENSOR_RHT> Enable Relative Humidity and Temperature sensor
 // <i> Default: 0

--- a/matter/efr32/efr32mg24/BRD4187A/config/sl_board_control_config.h
+++ b/matter/efr32/efr32mg24/BRD4187A/config/sl_board_control_config.h
@@ -9,7 +9,7 @@
 
 // <q SL_BOARD_ENABLE_DISPLAY> Enable Display
 // <i> Default: 0
-#define SL_BOARD_ENABLE_DISPLAY                 1
+#define SL_BOARD_ENABLE_DISPLAY                 0
 
 // <q SL_BOARD_ENABLE_SENSOR_RHT> Enable Relative Humidity and Temperature sensor
 // <i> Default: 0


### PR DESCRIPTION

#### Problem / Feature
When the disable_lcd build argument is enabled for BRD4164A, spotting on the LCD screen can be observed.

#### Change overview
Change the default of the DISP_ENABLE signal from 1 to 0. 

#### Testing
Tested on BRD4164A. Tested a build that enables the LCD, and tested a build that disables the LCD. Both have expected behavior with no spotting.