### PR TITLE
Add Missing BLE init function for BRD4317A

### DIFF
--- a/matter/efr32/mgm24/BRD4317A/autogen/sl_event_handler.c
+++ b/matter/efr32/mgm24/BRD4317A/autogen/sl_event_handler.c
@@ -47,7 +47,7 @@ void sl_platform_init(void)
   osKernelInitialize();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
   sl_power_manager_init();
-#endif
+#endif // SL_CATALOG_POWER_MANAGER_PRESENT
 }
 
 void sl_kernel_start(void)
@@ -78,6 +78,7 @@ void sl_stack_init(void)
 {
   sl_rail_util_pa_init();
   sl_rail_util_pti_init();
+  sl_bt_rtos_init();
 }
 
 void sl_internal_app_init(void)


### PR DESCRIPTION
#### Problem / Feature
* Missing ble RTOS init for the BRD4317A

#### Change overview
* Add init function in the kernal start
