### PR TITLE
Remove bt rtos init call from 1.0

### DIFF
--- a/matter/efr32/mgm24/BRD4317A/autogen/sl_event_handler.c
+++ b/matter/efr32/mgm24/BRD4317A/autogen/sl_event_handler.c
@@ -68,7 +68,6 @@ void sl_stack_init(void)
 {
   sl_rail_util_pa_init();
   sl_rail_util_pti_init();
-  sl_bt_rtos_init();
 }
 
 void sl_internal_app_init(void)


### PR DESCRIPTION
#### Problem / Feature
An bt rtos init call was added to the matter_1.0 branch when it shouldn't have. BT refactor is not in 1.0

#### Change overview
Removing the bt rtos init call
