### PR TITLE
[EFR32] MG12 63A/64A/70A Board bring up (#85)

### DIFF
--- a/matter/efr32/efr32mg12/BRD4163A/autogen/sl_component_catalog.h
+++ b/matter/efr32/efr32mg12/BRD4163A/autogen/sl_component_catalog.h
@@ -42,5 +42,4 @@
 #define SL_CATALOG_SENSOR_RHT_PRESENT
 #endif
 
-
 #endif // SL_COMPONENT_CATALOG_H

--- a/matter/efr32/efr32mg12/BRD4163A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4163A/autogen/sl_event_handler.c
@@ -20,6 +20,11 @@
 #if defined(CONFIG_ENABLE_UART)
 #include "sl_uartdrv_instances.h"
 #endif // CONFIG_ENABLE_UART
+
+#ifdef SL_WIFI
+#include "sl_spidrv_instances.h"
+#endif
+
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
 #include "sl_power_manager.h"
 #endif
@@ -53,6 +58,9 @@ void sl_kernel_start(void)
 void sl_driver_init(void)
 {
     GPIOINT_Init();
+#ifdef SL_WIFI
+    sl_spidrv_init_instances();
+#endif
     sl_simple_button_init_instances();
 #if defined(SL_CATALOG_SENSOR_RHT_PRESENT)
     sl_i2cspm_init_instances();

--- a/matter/efr32/efr32mg12/BRD4163A/autogen/sl_spidrv_init.c
+++ b/matter/efr32/efr32mg12/BRD4163A/autogen/sl_spidrv_init.c
@@ -1,0 +1,48 @@
+#include "spidrv.h"
+#include "sl_spidrv_instances.h"
+#include "em_assert.h"
+
+
+#include "sl_spidrv_exp_config.h"
+
+SPIDRV_HandleData_t sl_spidrv_exp_handle_data;
+SPIDRV_Handle_t sl_spidrv_exp_handle = &sl_spidrv_exp_handle_data;
+
+SPIDRV_Init_t sl_spidrv_init_exp = {
+  .port = SL_SPIDRV_EXP_PERIPHERAL,
+#if defined(_USART_ROUTELOC0_MASK)
+  .portLocationTx = SL_SPIDRV_EXP_TX_LOC,
+  .portLocationRx = SL_SPIDRV_EXP_RX_LOC,
+  .portLocationClk = SL_SPIDRV_EXP_CLK_LOC,
+#if defined(SL_SPIDRV_EXP_CS_LOC)
+  .portLocationCs = SL_SPIDRV_EXP_CS_LOC,
+#endif
+#elif defined(_GPIO_USART_ROUTEEN_MASK)
+  .portTx = SL_SPIDRV_EXP_TX_PORT,
+  .portRx = SL_SPIDRV_EXP_RX_PORT,
+  .portClk = SL_SPIDRV_EXP_CLK_PORT,
+#if defined(SL_SPIDRV_EXP_CS_PORT)
+  .portCs = SL_SPIDRV_EXP_CS_PORT,
+#endif
+  .pinTx = SL_SPIDRV_EXP_TX_PIN,
+  .pinRx = SL_SPIDRV_EXP_RX_PIN,
+  .pinClk = SL_SPIDRV_EXP_CLK_PIN,
+#if defined(SL_SPIDRV_EXP_CS_PIN)
+  .pinCs = SL_SPIDRV_EXP_CS_PIN,
+#endif
+#else
+  .portLocation = SL_SPIDRV_EXP_ROUTE_LOC,
+#endif
+  .bitRate = SL_SPIDRV_EXP_BITRATE,
+  .frameLength = SL_SPIDRV_EXP_FRAME_LENGTH,
+  .dummyTxValue = 0,
+  .type = SL_SPIDRV_EXP_TYPE,
+  .bitOrder = SL_SPIDRV_EXP_BIT_ORDER,
+  .clockMode = SL_SPIDRV_EXP_CLOCK_MODE,
+  .csControl = SL_SPIDRV_EXP_CS_CONTROL,
+  .slaveStartMode = SL_SPIDRV_EXP_SLAVE_START_MODE,
+};
+
+void sl_spidrv_init_instances(void) {
+  SPIDRV_Init(sl_spidrv_exp_handle, &sl_spidrv_init_exp);
+}

--- a/matter/efr32/efr32mg12/BRD4163A/autogen/sl_spidrv_instances.h
+++ b/matter/efr32/efr32mg12/BRD4163A/autogen/sl_spidrv_instances.h
@@ -1,0 +1,17 @@
+#ifndef SL_SPIDRV_INSTANCES_H
+#define SL_SPIDRV_INSTANCES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "spidrv.h"
+extern SPIDRV_Handle_t sl_spidrv_exp_handle;
+
+void sl_spidrv_init_instances(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SL_SPIDRV_INSTANCES_H

--- a/matter/efr32/efr32mg12/BRD4163A/config/brd4161a.h
+++ b/matter/efr32/efr32mg12/BRD4163A/config/brd4161a.h
@@ -1,0 +1,33 @@
+#ifndef _BRD4161A_H_
+#define _BRD4161A_H_
+#ifndef LOGGING_STATS
+#define WAKE_INDICATOR_PIN PIN(D, 3)
+#endif
+
+#ifdef LOGGING_STATS
+#define LOGGING_WAKE_INDICATOR_PIN PIN(D, 3)
+#define LOGGING_STATS_PORT gpioPortD
+#define LOGGING_STATS_PIN 03
+#endif
+
+#define MY_USART USART2
+#define MY_USART_TX_SIGNAL dmadrvPeripheralSignal_USART2_TXBL
+#define MY_USART_RX_SIGNAL dmadrvPeripheralSignal_USART2_RXDATAV
+
+
+#ifdef RS911X_WIFI
+#define WFX_RESET_PIN     PIN(D, 12)
+#define WFX_INTERRUPT_PIN PIN(C, 9)
+#define WFX_SLEEP_CONFIRM_PIN      PIN(D, 13)
+#define SL_WFX_HOST_PINOUT_SPI_IRQ 9
+#else /* WF200 */
+#define SL_WFX_HOST_PINOUT_RESET_PORT gpioPortD
+#define SL_WFX_HOST_PINOUT_RESET_PIN 10
+#define SL_WFX_HOST_PINOUT_SPI_WIRQ_PORT gpioPortB /* SPI IRQ port*/
+#define SL_WFX_HOST_PINOUT_SPI_WIRQ_PIN 6          /* SPI IRQ pin */
+#define SL_WFX_HOST_PINOUT_WUP_PORT gpioPortD
+#define SL_WFX_HOST_PINOUT_WUP_PIN 8
+#define SL_WFX_HOST_PINOUT_SPI_IRQ 5
+#endif /* WF200/9116 */
+
+#endif /* _BRD4161A_H_ */

--- a/matter/efr32/efr32mg12/BRD4163A/config/sl_spidrv_exp_config.h
+++ b/matter/efr32/efr32mg12/BRD4163A/config/sl_spidrv_exp_config.h
@@ -1,0 +1,98 @@
+/***************************************************************************//**
+ * @file
+ * @brief SPIDRV Config
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+
+#ifndef SL_SPIDRV_EXP_CONFIG_H
+#define SL_SPIDRV_EXP_CONFIG_H
+
+#include "spidrv.h"
+
+// <<< Use Configuration Wizard in Context Menu >>>
+// <h> SPIDRV settings
+
+// <o SL_SPIDRV_EXP_BITRATE> SPI bitrate
+// <i> Default: 1000000
+#ifdef RS911X_WIFI
+#define SL_SPIDRV_EXP_BITRATE           10000000
+#endif
+
+#if WF200_WIFI
+#define SL_SPIDRV_EXP_BITRATE           20000000
+#endif
+
+// <o SL_SPIDRV_EXP_FRAME_LENGTH> SPI frame length <4-16>
+// <i> Default: 8
+#define SL_SPIDRV_EXP_FRAME_LENGTH      8
+
+// <o SL_SPIDRV_EXP_TYPE> SPI mode
+// <spidrvMaster=> Master
+// <spidrvSlave=> Slave
+#define SL_SPIDRV_EXP_TYPE              spidrvMaster
+
+// <o SL_SPIDRV_EXP_BIT_ORDER> Bit order on the SPI bus
+// <spidrvBitOrderLsbFirst=> LSB transmitted first
+// <spidrvBitOrderMsbFirst=> MSB transmitted first
+#define SL_SPIDRV_EXP_BIT_ORDER         spidrvBitOrderMsbFirst
+
+// <o SL_SPIDRV_EXP_CLOCK_MODE> SPI clock mode
+// <spidrvClockMode0=> SPI mode 0: CLKPOL=0, CLKPHA=0
+// <spidrvClockMode1=> SPI mode 1: CLKPOL=0, CLKPHA=1
+// <spidrvClockMode2=> SPI mode 2: CLKPOL=1, CLKPHA=0
+// <spidrvClockMode3=> SPI mode 3: CLKPOL=1, CLKPHA=1
+#define SL_SPIDRV_EXP_CLOCK_MODE        spidrvClockMode0
+
+// <o SL_SPIDRV_EXP_CS_CONTROL> SPI master chip select (CS) control scheme.
+// <spidrvCsControlAuto=> CS controlled by the SPI driver
+// <spidrvCsControlApplication=> CS controlled by the application
+#define SL_SPIDRV_EXP_CS_CONTROL        spidrvCsControlAuto
+
+// <o SL_SPIDRV_EXP_SLAVE_START_MODE> SPI slave transfer start scheme
+// <spidrvSlaveStartImmediate=> Transfer starts immediately
+// <spidrvSlaveStartDelayed=> Transfer starts when the bus is idle (CS deasserted)
+// <i> Only applies if instance type is spidrvSlave
+#define SL_SPIDRV_EXP_SLAVE_START_MODE  spidrvSlaveStartImmediate
+// </h>
+// <<< end of configuration section >>>
+
+// <<< sl:start pin_tool >>>
+// <usart signal=TX,RX,CLK,(CS)> SL_SPIDRV_EXP
+// $[USART_SL_SPIDRV_EXP]
+#define SL_SPIDRV_EXP_PERIPHERAL                 USART2
+#define SL_SPIDRV_EXP_PERIPHERAL_NO              2
+
+// USART2 TX on PA6
+#define SL_SPIDRV_EXP_TX_PORT                    gpioPortA
+#define SL_SPIDRV_EXP_TX_PIN                     6
+#define SL_SPIDRV_EXP_TX_LOC                     1
+
+// USART2 RX on PA7
+#define SL_SPIDRV_EXP_RX_PORT                    gpioPortA
+#define SL_SPIDRV_EXP_RX_PIN                     7
+#define SL_SPIDRV_EXP_RX_LOC                     1
+
+// USART2 CLK on PA8
+#define SL_SPIDRV_EXP_CLK_PORT                   gpioPortA
+#define SL_SPIDRV_EXP_CLK_PIN                    8
+#define SL_SPIDRV_EXP_CLK_LOC                    1
+
+// USART2 CS on PA9
+#define SL_SPIDRV_EXP_CS_PORT                    gpioPortA
+#define SL_SPIDRV_EXP_CS_PIN                     9
+#define SL_SPIDRV_EXP_CS_LOC                     1
+// [USART_SL_SPIDRV_EXP]$
+// <<< sl:end pin_tool >>>
+
+#endif // SL_SPIDRV_EXP_CONFIG_H

--- a/matter/efr32/efr32mg12/BRD4163A/config/spidrv_config.h
+++ b/matter/efr32/efr32mg12/BRD4163A/config/spidrv_config.h
@@ -1,0 +1,43 @@
+/***************************************************************************//**
+ * @file
+ * @brief SPIDRV configuration file.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#ifndef __SILICON_LABS_SPIDRV_CONFIG_H__
+#define __SILICON_LABS_SPIDRV_CONFIG_H__
+
+/***************************************************************************//**
+ * @addtogroup spidrv
+ * @{
+ ******************************************************************************/
+
+/// SPIDRV configuration option. Use this define to include the slave part of the SPIDRV API.
+#define EMDRV_SPIDRV_INCLUDE_SLAVE
+
+/** @} (end addtogroup spidrv) */
+
+#endif /* __SILICON_LABS_SPIDRV_CONFIG_H__ */

--- a/matter/efr32/efr32mg12/BRD4164A/autogen/sl_component_catalog.h
+++ b/matter/efr32/efr32mg12/BRD4164A/autogen/sl_component_catalog.h
@@ -42,5 +42,4 @@
 #define SL_CATALOG_SENSOR_RHT_PRESENT
 #endif
 
-
 #endif // SL_COMPONENT_CATALOG_H

--- a/matter/efr32/efr32mg12/BRD4164A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4164A/autogen/sl_event_handler.c
@@ -20,6 +20,11 @@
 #if defined(CONFIG_ENABLE_UART)
 #include "sl_uartdrv_instances.h"
 #endif // CONFIG_ENABLE_UART
+
+#ifdef SL_WIFI
+#include "sl_spidrv_instances.h"
+#endif
+
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
 #include "sl_power_manager.h"
 #endif
@@ -52,6 +57,9 @@ void sl_kernel_start(void)
 void sl_driver_init(void)
 {
     GPIOINT_Init();
+#ifdef SL_WIFI
+    sl_spidrv_init_instances();
+#endif
     sl_simple_button_init_instances();
 #if defined(SL_CATALOG_SENSOR_RHT_PRESENT)
     sl_i2cspm_init_instances();

--- a/matter/efr32/efr32mg12/BRD4164A/autogen/sl_spidrv_init.c
+++ b/matter/efr32/efr32mg12/BRD4164A/autogen/sl_spidrv_init.c
@@ -1,0 +1,48 @@
+#include "spidrv.h"
+#include "sl_spidrv_instances.h"
+#include "em_assert.h"
+
+
+#include "sl_spidrv_exp_config.h"
+
+SPIDRV_HandleData_t sl_spidrv_exp_handle_data;
+SPIDRV_Handle_t sl_spidrv_exp_handle = &sl_spidrv_exp_handle_data;
+
+SPIDRV_Init_t sl_spidrv_init_exp = {
+  .port = SL_SPIDRV_EXP_PERIPHERAL,
+#if defined(_USART_ROUTELOC0_MASK)
+  .portLocationTx = SL_SPIDRV_EXP_TX_LOC,
+  .portLocationRx = SL_SPIDRV_EXP_RX_LOC,
+  .portLocationClk = SL_SPIDRV_EXP_CLK_LOC,
+#if defined(SL_SPIDRV_EXP_CS_LOC)
+  .portLocationCs = SL_SPIDRV_EXP_CS_LOC,
+#endif
+#elif defined(_GPIO_USART_ROUTEEN_MASK)
+  .portTx = SL_SPIDRV_EXP_TX_PORT,
+  .portRx = SL_SPIDRV_EXP_RX_PORT,
+  .portClk = SL_SPIDRV_EXP_CLK_PORT,
+#if defined(SL_SPIDRV_EXP_CS_PORT)
+  .portCs = SL_SPIDRV_EXP_CS_PORT,
+#endif
+  .pinTx = SL_SPIDRV_EXP_TX_PIN,
+  .pinRx = SL_SPIDRV_EXP_RX_PIN,
+  .pinClk = SL_SPIDRV_EXP_CLK_PIN,
+#if defined(SL_SPIDRV_EXP_CS_PIN)
+  .pinCs = SL_SPIDRV_EXP_CS_PIN,
+#endif
+#else
+  .portLocation = SL_SPIDRV_EXP_ROUTE_LOC,
+#endif
+  .bitRate = SL_SPIDRV_EXP_BITRATE,
+  .frameLength = SL_SPIDRV_EXP_FRAME_LENGTH,
+  .dummyTxValue = 0,
+  .type = SL_SPIDRV_EXP_TYPE,
+  .bitOrder = SL_SPIDRV_EXP_BIT_ORDER,
+  .clockMode = SL_SPIDRV_EXP_CLOCK_MODE,
+  .csControl = SL_SPIDRV_EXP_CS_CONTROL,
+  .slaveStartMode = SL_SPIDRV_EXP_SLAVE_START_MODE,
+};
+
+void sl_spidrv_init_instances(void) {
+  SPIDRV_Init(sl_spidrv_exp_handle, &sl_spidrv_init_exp);
+}

--- a/matter/efr32/efr32mg12/BRD4164A/autogen/sl_spidrv_instances.h
+++ b/matter/efr32/efr32mg12/BRD4164A/autogen/sl_spidrv_instances.h
@@ -1,0 +1,17 @@
+#ifndef SL_SPIDRV_INSTANCES_H
+#define SL_SPIDRV_INSTANCES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "spidrv.h"
+extern SPIDRV_Handle_t sl_spidrv_exp_handle;
+
+void sl_spidrv_init_instances(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SL_SPIDRV_INSTANCES_H

--- a/matter/efr32/efr32mg12/BRD4164A/config/brd4161a.h
+++ b/matter/efr32/efr32mg12/BRD4164A/config/brd4161a.h
@@ -1,0 +1,33 @@
+#ifndef _BRD4161A_H_
+#define _BRD4161A_H_
+#ifndef LOGGING_STATS
+#define WAKE_INDICATOR_PIN PIN(D, 3)
+#endif
+
+#ifdef LOGGING_STATS
+#define LOGGING_WAKE_INDICATOR_PIN PIN(D, 3)
+#define LOGGING_STATS_PORT gpioPortD
+#define LOGGING_STATS_PIN 03
+#endif
+
+#define MY_USART USART2
+#define MY_USART_TX_SIGNAL dmadrvPeripheralSignal_USART2_TXBL
+#define MY_USART_RX_SIGNAL dmadrvPeripheralSignal_USART2_RXDATAV
+
+
+#ifdef RS911X_WIFI
+#define WFX_RESET_PIN     PIN(D, 12)
+#define WFX_INTERRUPT_PIN PIN(C, 9)
+#define WFX_SLEEP_CONFIRM_PIN      PIN(D, 13)
+#define SL_WFX_HOST_PINOUT_SPI_IRQ 9
+#else /* WF200 */
+#define SL_WFX_HOST_PINOUT_RESET_PORT gpioPortD
+#define SL_WFX_HOST_PINOUT_RESET_PIN 10
+#define SL_WFX_HOST_PINOUT_SPI_WIRQ_PORT gpioPortB /* SPI IRQ port*/
+#define SL_WFX_HOST_PINOUT_SPI_WIRQ_PIN 6          /* SPI IRQ pin */
+#define SL_WFX_HOST_PINOUT_WUP_PORT gpioPortD
+#define SL_WFX_HOST_PINOUT_WUP_PIN 8
+#define SL_WFX_HOST_PINOUT_SPI_IRQ 5
+#endif /* WF200/9116 */
+
+#endif /* _BRD4161A_H_ */

--- a/matter/efr32/efr32mg12/BRD4164A/config/sl_spidrv_exp_config.h
+++ b/matter/efr32/efr32mg12/BRD4164A/config/sl_spidrv_exp_config.h
@@ -1,0 +1,98 @@
+/***************************************************************************//**
+ * @file
+ * @brief SPIDRV Config
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+
+#ifndef SL_SPIDRV_EXP_CONFIG_H
+#define SL_SPIDRV_EXP_CONFIG_H
+
+#include "spidrv.h"
+
+// <<< Use Configuration Wizard in Context Menu >>>
+// <h> SPIDRV settings
+
+// <o SL_SPIDRV_EXP_BITRATE> SPI bitrate
+// <i> Default: 1000000
+#ifdef RS911X_WIFI
+#define SL_SPIDRV_EXP_BITRATE           10000000
+#endif
+
+#if WF200_WIFI
+#define SL_SPIDRV_EXP_BITRATE           20000000
+#endif
+
+// <o SL_SPIDRV_EXP_FRAME_LENGTH> SPI frame length <4-16>
+// <i> Default: 8
+#define SL_SPIDRV_EXP_FRAME_LENGTH      8
+
+// <o SL_SPIDRV_EXP_TYPE> SPI mode
+// <spidrvMaster=> Master
+// <spidrvSlave=> Slave
+#define SL_SPIDRV_EXP_TYPE              spidrvMaster
+
+// <o SL_SPIDRV_EXP_BIT_ORDER> Bit order on the SPI bus
+// <spidrvBitOrderLsbFirst=> LSB transmitted first
+// <spidrvBitOrderMsbFirst=> MSB transmitted first
+#define SL_SPIDRV_EXP_BIT_ORDER         spidrvBitOrderMsbFirst
+
+// <o SL_SPIDRV_EXP_CLOCK_MODE> SPI clock mode
+// <spidrvClockMode0=> SPI mode 0: CLKPOL=0, CLKPHA=0
+// <spidrvClockMode1=> SPI mode 1: CLKPOL=0, CLKPHA=1
+// <spidrvClockMode2=> SPI mode 2: CLKPOL=1, CLKPHA=0
+// <spidrvClockMode3=> SPI mode 3: CLKPOL=1, CLKPHA=1
+#define SL_SPIDRV_EXP_CLOCK_MODE        spidrvClockMode0
+
+// <o SL_SPIDRV_EXP_CS_CONTROL> SPI master chip select (CS) control scheme.
+// <spidrvCsControlAuto=> CS controlled by the SPI driver
+// <spidrvCsControlApplication=> CS controlled by the application
+#define SL_SPIDRV_EXP_CS_CONTROL        spidrvCsControlAuto
+
+// <o SL_SPIDRV_EXP_SLAVE_START_MODE> SPI slave transfer start scheme
+// <spidrvSlaveStartImmediate=> Transfer starts immediately
+// <spidrvSlaveStartDelayed=> Transfer starts when the bus is idle (CS deasserted)
+// <i> Only applies if instance type is spidrvSlave
+#define SL_SPIDRV_EXP_SLAVE_START_MODE  spidrvSlaveStartImmediate
+// </h>
+// <<< end of configuration section >>>
+
+// <<< sl:start pin_tool >>>
+// <usart signal=TX,RX,CLK,(CS)> SL_SPIDRV_EXP
+// $[USART_SL_SPIDRV_EXP]
+#define SL_SPIDRV_EXP_PERIPHERAL                 USART2
+#define SL_SPIDRV_EXP_PERIPHERAL_NO              2
+
+// USART2 TX on PA6
+#define SL_SPIDRV_EXP_TX_PORT                    gpioPortA
+#define SL_SPIDRV_EXP_TX_PIN                     6
+#define SL_SPIDRV_EXP_TX_LOC                     1
+
+// USART2 RX on PA7
+#define SL_SPIDRV_EXP_RX_PORT                    gpioPortA
+#define SL_SPIDRV_EXP_RX_PIN                     7
+#define SL_SPIDRV_EXP_RX_LOC                     1
+
+// USART2 CLK on PA8
+#define SL_SPIDRV_EXP_CLK_PORT                   gpioPortA
+#define SL_SPIDRV_EXP_CLK_PIN                    8
+#define SL_SPIDRV_EXP_CLK_LOC                    1
+
+// USART2 CS on PA9
+#define SL_SPIDRV_EXP_CS_PORT                    gpioPortA
+#define SL_SPIDRV_EXP_CS_PIN                     9
+#define SL_SPIDRV_EXP_CS_LOC                     1
+// [USART_SL_SPIDRV_EXP]$
+// <<< sl:end pin_tool >>>
+
+#endif // SL_SPIDRV_EXP_CONFIG_H

--- a/matter/efr32/efr32mg12/BRD4164A/config/spidrv_config.h
+++ b/matter/efr32/efr32mg12/BRD4164A/config/spidrv_config.h
@@ -1,0 +1,43 @@
+/***************************************************************************//**
+ * @file
+ * @brief SPIDRV configuration file.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#ifndef __SILICON_LABS_SPIDRV_CONFIG_H__
+#define __SILICON_LABS_SPIDRV_CONFIG_H__
+
+/***************************************************************************//**
+ * @addtogroup spidrv
+ * @{
+ ******************************************************************************/
+
+/// SPIDRV configuration option. Use this define to include the slave part of the SPIDRV API.
+#define EMDRV_SPIDRV_INCLUDE_SLAVE
+
+/** @} (end addtogroup spidrv) */
+
+#endif /* __SILICON_LABS_SPIDRV_CONFIG_H__ */

--- a/matter/efr32/efr32mg12/BRD4170A/autogen/sl_component_catalog.h
+++ b/matter/efr32/efr32mg12/BRD4170A/autogen/sl_component_catalog.h
@@ -42,5 +42,4 @@
 #define SL_CATALOG_SENSOR_RHT_PRESENT
 #endif
 
-
 #endif // SL_COMPONENT_CATALOG_H

--- a/matter/efr32/efr32mg12/BRD4170A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4170A/autogen/sl_event_handler.c
@@ -20,6 +20,11 @@
 #if defined(CONFIG_ENABLE_UART)
 #include "sl_uartdrv_instances.h"
 #endif // CONFIG_ENABLE_UART
+
+#ifdef SL_WIFI
+#include "sl_spidrv_instances.h"
+#endif
+
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
 #include "sl_power_manager.h"
 #endif
@@ -52,6 +57,9 @@ void sl_kernel_start(void)
 void sl_driver_init(void)
 {
     GPIOINT_Init();
+#ifdef SL_WIFI
+    sl_spidrv_init_instances();
+#endif
     sl_simple_button_init_instances();
 #if defined(SL_CATALOG_SENSOR_RHT_PRESENT)
     sl_i2cspm_init_instances();

--- a/matter/efr32/efr32mg12/BRD4170A/autogen/sl_spidrv_init.c
+++ b/matter/efr32/efr32mg12/BRD4170A/autogen/sl_spidrv_init.c
@@ -1,0 +1,48 @@
+#include "spidrv.h"
+#include "sl_spidrv_instances.h"
+#include "em_assert.h"
+
+
+#include "sl_spidrv_exp_config.h"
+
+SPIDRV_HandleData_t sl_spidrv_exp_handle_data;
+SPIDRV_Handle_t sl_spidrv_exp_handle = &sl_spidrv_exp_handle_data;
+
+SPIDRV_Init_t sl_spidrv_init_exp = {
+  .port = SL_SPIDRV_EXP_PERIPHERAL,
+#if defined(_USART_ROUTELOC0_MASK)
+  .portLocationTx = SL_SPIDRV_EXP_TX_LOC,
+  .portLocationRx = SL_SPIDRV_EXP_RX_LOC,
+  .portLocationClk = SL_SPIDRV_EXP_CLK_LOC,
+#if defined(SL_SPIDRV_EXP_CS_LOC)
+  .portLocationCs = SL_SPIDRV_EXP_CS_LOC,
+#endif
+#elif defined(_GPIO_USART_ROUTEEN_MASK)
+  .portTx = SL_SPIDRV_EXP_TX_PORT,
+  .portRx = SL_SPIDRV_EXP_RX_PORT,
+  .portClk = SL_SPIDRV_EXP_CLK_PORT,
+#if defined(SL_SPIDRV_EXP_CS_PORT)
+  .portCs = SL_SPIDRV_EXP_CS_PORT,
+#endif
+  .pinTx = SL_SPIDRV_EXP_TX_PIN,
+  .pinRx = SL_SPIDRV_EXP_RX_PIN,
+  .pinClk = SL_SPIDRV_EXP_CLK_PIN,
+#if defined(SL_SPIDRV_EXP_CS_PIN)
+  .pinCs = SL_SPIDRV_EXP_CS_PIN,
+#endif
+#else
+  .portLocation = SL_SPIDRV_EXP_ROUTE_LOC,
+#endif
+  .bitRate = SL_SPIDRV_EXP_BITRATE,
+  .frameLength = SL_SPIDRV_EXP_FRAME_LENGTH,
+  .dummyTxValue = 0,
+  .type = SL_SPIDRV_EXP_TYPE,
+  .bitOrder = SL_SPIDRV_EXP_BIT_ORDER,
+  .clockMode = SL_SPIDRV_EXP_CLOCK_MODE,
+  .csControl = SL_SPIDRV_EXP_CS_CONTROL,
+  .slaveStartMode = SL_SPIDRV_EXP_SLAVE_START_MODE,
+};
+
+void sl_spidrv_init_instances(void) {
+  SPIDRV_Init(sl_spidrv_exp_handle, &sl_spidrv_init_exp);
+}

--- a/matter/efr32/efr32mg12/BRD4170A/autogen/sl_spidrv_instances.h
+++ b/matter/efr32/efr32mg12/BRD4170A/autogen/sl_spidrv_instances.h
@@ -1,0 +1,17 @@
+#ifndef SL_SPIDRV_INSTANCES_H
+#define SL_SPIDRV_INSTANCES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "spidrv.h"
+extern SPIDRV_Handle_t sl_spidrv_exp_handle;
+
+void sl_spidrv_init_instances(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SL_SPIDRV_INSTANCES_H

--- a/matter/efr32/efr32mg12/BRD4170A/config/brd4161a.h
+++ b/matter/efr32/efr32mg12/BRD4170A/config/brd4161a.h
@@ -1,0 +1,33 @@
+#ifndef _BRD4161A_H_
+#define _BRD4161A_H_
+#ifndef LOGGING_STATS
+#define WAKE_INDICATOR_PIN PIN(D, 3)
+#endif
+
+#ifdef LOGGING_STATS
+#define LOGGING_WAKE_INDICATOR_PIN PIN(D, 3)
+#define LOGGING_STATS_PORT gpioPortD
+#define LOGGING_STATS_PIN 03
+#endif
+
+#define MY_USART USART3
+#define MY_USART_TX_SIGNAL dmadrvPeripheralSignal_USART3_TXBL
+#define MY_USART_RX_SIGNAL dmadrvPeripheralSignal_USART3_RXDATAV
+
+
+#ifdef RS911X_WIFI
+#define WFX_RESET_PIN     PIN(D, 12)
+#define WFX_INTERRUPT_PIN PIN(C, 9)
+#define WFX_SLEEP_CONFIRM_PIN      PIN(D, 13)
+#define SL_WFX_HOST_PINOUT_SPI_IRQ 9
+#else /* WF200 */
+#define SL_WFX_HOST_PINOUT_RESET_PORT gpioPortD
+#define SL_WFX_HOST_PINOUT_RESET_PIN 10
+#define SL_WFX_HOST_PINOUT_SPI_WIRQ_PORT gpioPortC /* SPI IRQ port*/
+#define SL_WFX_HOST_PINOUT_SPI_WIRQ_PIN 4          /* SPI IRQ pin */
+#define SL_WFX_HOST_PINOUT_WUP_PORT gpioPortD
+#define SL_WFX_HOST_PINOUT_WUP_PIN 8
+#define SL_WFX_HOST_PINOUT_SPI_IRQ 5
+#endif /* WF200/9116 */
+
+#endif /* _BRD4161A_H_ */

--- a/matter/efr32/efr32mg12/BRD4170A/config/sl_spidrv_exp_config.h
+++ b/matter/efr32/efr32mg12/BRD4170A/config/sl_spidrv_exp_config.h
@@ -1,0 +1,98 @@
+/***************************************************************************//**
+ * @file
+ * @brief SPIDRV Config
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+
+#ifndef SL_SPIDRV_EXP_CONFIG_H
+#define SL_SPIDRV_EXP_CONFIG_H
+
+#include "spidrv.h"
+
+// <<< Use Configuration Wizard in Context Menu >>>
+// <h> SPIDRV settings
+
+// <o SL_SPIDRV_EXP_BITRATE> SPI bitrate
+// <i> Default: 1000000
+#ifdef RS911X_WIFI
+#define SL_SPIDRV_EXP_BITRATE           10000000
+#endif
+
+#if WF200_WIFI
+#define SL_SPIDRV_EXP_BITRATE           20000000
+#endif
+
+// <o SL_SPIDRV_EXP_FRAME_LENGTH> SPI frame length <4-16>
+// <i> Default: 8
+#define SL_SPIDRV_EXP_FRAME_LENGTH      8
+
+// <o SL_SPIDRV_EXP_TYPE> SPI mode
+// <spidrvMaster=> Master
+// <spidrvSlave=> Slave
+#define SL_SPIDRV_EXP_TYPE              spidrvMaster
+
+// <o SL_SPIDRV_EXP_BIT_ORDER> Bit order on the SPI bus
+// <spidrvBitOrderLsbFirst=> LSB transmitted first
+// <spidrvBitOrderMsbFirst=> MSB transmitted first
+#define SL_SPIDRV_EXP_BIT_ORDER         spidrvBitOrderMsbFirst
+
+// <o SL_SPIDRV_EXP_CLOCK_MODE> SPI clock mode
+// <spidrvClockMode0=> SPI mode 0: CLKPOL=0, CLKPHA=0
+// <spidrvClockMode1=> SPI mode 1: CLKPOL=0, CLKPHA=1
+// <spidrvClockMode2=> SPI mode 2: CLKPOL=1, CLKPHA=0
+// <spidrvClockMode3=> SPI mode 3: CLKPOL=1, CLKPHA=1
+#define SL_SPIDRV_EXP_CLOCK_MODE        spidrvClockMode0
+
+// <o SL_SPIDRV_EXP_CS_CONTROL> SPI master chip select (CS) control scheme.
+// <spidrvCsControlAuto=> CS controlled by the SPI driver
+// <spidrvCsControlApplication=> CS controlled by the application
+#define SL_SPIDRV_EXP_CS_CONTROL        spidrvCsControlAuto
+
+// <o SL_SPIDRV_EXP_SLAVE_START_MODE> SPI slave transfer start scheme
+// <spidrvSlaveStartImmediate=> Transfer starts immediately
+// <spidrvSlaveStartDelayed=> Transfer starts when the bus is idle (CS deasserted)
+// <i> Only applies if instance type is spidrvSlave
+#define SL_SPIDRV_EXP_SLAVE_START_MODE  spidrvSlaveStartImmediate
+// </h>
+// <<< end of configuration section >>>
+
+// <<< sl:start pin_tool >>>
+// <usart signal=TX,RX,CLK,(CS)> SL_SPIDRV_EXP
+// $[USART_SL_SPIDRV_EXP]
+#define SL_SPIDRV_EXP_PERIPHERAL                 USART3
+#define SL_SPIDRV_EXP_PERIPHERAL_NO              3
+
+// USART2 TX on PA6
+#define SL_SPIDRV_EXP_TX_PORT                    gpioPortC
+#define SL_SPIDRV_EXP_TX_PIN                     0
+#define SL_SPIDRV_EXP_TX_LOC                     18
+
+// USART2 RX on PA7
+#define SL_SPIDRV_EXP_RX_PORT                    gpioPortC
+#define SL_SPIDRV_EXP_RX_PIN                     1
+#define SL_SPIDRV_EXP_RX_LOC                     18
+
+// USART2 CLK on PA8
+#define SL_SPIDRV_EXP_CLK_PORT                   gpioPortC
+#define SL_SPIDRV_EXP_CLK_PIN                    2
+#define SL_SPIDRV_EXP_CLK_LOC                    18
+
+// USART2 CS on PA9
+#define SL_SPIDRV_EXP_CS_PORT                    gpioPortC
+#define SL_SPIDRV_EXP_CS_PIN                     3
+#define SL_SPIDRV_EXP_CS_LOC                     18
+// [USART_SL_SPIDRV_EXP]$
+// <<< sl:end pin_tool >>>
+
+#endif // SL_SPIDRV_EXP_CONFIG_H

--- a/matter/efr32/efr32mg12/BRD4170A/config/spidrv_config.h
+++ b/matter/efr32/efr32mg12/BRD4170A/config/spidrv_config.h
@@ -1,0 +1,43 @@
+/***************************************************************************//**
+ * @file
+ * @brief SPIDRV configuration file.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#ifndef __SILICON_LABS_SPIDRV_CONFIG_H__
+#define __SILICON_LABS_SPIDRV_CONFIG_H__
+
+/***************************************************************************//**
+ * @addtogroup spidrv
+ * @{
+ ******************************************************************************/
+
+/// SPIDRV configuration option. Use this define to include the slave part of the SPIDRV API.
+#define EMDRV_SPIDRV_INCLUDE_SLAVE
+
+/** @} (end addtogroup spidrv) */
+
+#endif /* __SILICON_LABS_SPIDRV_CONFIG_H__ */


### PR DESCRIPTION
MG12 63A/64A/70A Board bring up

Problem / Feature
What is being fixed? What is the feature being added? Examples:

Added changes to initialize MG12 - 70A/63A/64A Boards
Changes include Wi-Fi initialization and SPI pin Configuration w.r.t RS9116 and WF200
Testing
How was this tested?
Manually Tested below scenario's

Build is successful
Commissioning is successful
Sanity completed with MG12-70A/63A/64A with RS9116 and WF200 on one application (Lighting App).