### PR TITLE
Added changes for RS9116 BLE integration

### DIFF
--- a/matter/efr32/efr32mg12/BRD4162A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4162A/autogen/sl_event_handler.c
@@ -86,7 +86,9 @@ void sl_stack_init(void)
 {
   sl_rail_util_pa_init();
   sl_rail_util_pti_init();
-  sl_bt_rtos_init();
+#if !RS91X_BLE_ENABLE
+     sl_bt_rtos_init();
+#endif
 }
 
 void sl_internal_app_init(void)

--- a/matter/efr32/efr32mg12/BRD4163A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4163A/autogen/sl_event_handler.c
@@ -82,7 +82,9 @@ void sl_stack_init(void)
 {
     sl_rail_util_pa_init();
     sl_rail_util_pti_init();
-    sl_bt_rtos_init();
+#if !RS91X_BLE_ENABLE
+     sl_bt_rtos_init();
+#endif
 }
 
 void sl_internal_app_init(void) {}

--- a/matter/efr32/efr32mg12/BRD4164A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4164A/autogen/sl_event_handler.c
@@ -81,7 +81,9 @@ void sl_stack_init(void)
 {
     sl_rail_util_pa_init();
     sl_rail_util_pti_init();
-    sl_bt_rtos_init();
+#if !RS91X_BLE_ENABLE
+     sl_bt_rtos_init();
+#endif
 }
 
 void sl_internal_app_init(void) {}

--- a/matter/efr32/efr32mg12/BRD4166A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4166A/autogen/sl_event_handler.c
@@ -74,7 +74,9 @@ void sl_stack_init(void)
 {
   sl_rail_util_pa_init();
   sl_rail_util_pti_init();
-  sl_bt_rtos_init();
+#if !RS91X_BLE_ENABLE
+     sl_bt_rtos_init();
+#endif
 }
 
 void sl_internal_app_init(void) {}

--- a/matter/efr32/efr32mg12/BRD4170A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4170A/autogen/sl_event_handler.c
@@ -82,7 +82,9 @@ void sl_stack_init(void)
 {
   sl_rail_util_pa_init();
   sl_rail_util_pti_init();
-  sl_bt_rtos_init();
+#if !RS91X_BLE_ENABLE
+     sl_bt_rtos_init();
+#endif
 }
 
 void sl_internal_app_init(void) {}

--- a/matter/efr32/efr32mg12/BRD4304A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4304A/autogen/sl_event_handler.c
@@ -73,7 +73,9 @@ void sl_stack_init(void)
 {
   sl_rail_util_pa_init();
   sl_rail_util_pti_init();
-  sl_bt_rtos_init();
+#if !RS91X_BLE_ENABLE
+     sl_bt_rtos_init();
+#endif
 }
 
 void sl_internal_app_init(void) {}

--- a/matter/efr32/efr32mg24/BRD2601B/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg24/BRD2601B/autogen/sl_event_handler.c
@@ -82,7 +82,9 @@ void sl_stack_init(void)
 {
   sl_rail_util_pa_init();
   sl_rail_util_pti_init();
-  sl_bt_rtos_init();
+#if !RS91X_BLE_ENABLE
+     sl_bt_rtos_init();
+#endif
 }
 
 void sl_internal_app_init(void) {}

--- a/matter/efr32/efr32mg24/BRD2703A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg24/BRD2703A/autogen/sl_event_handler.c
@@ -71,7 +71,9 @@ void sl_stack_init(void)
 {
   sl_rail_util_pa_init();
   sl_rail_util_pti_init();
-  sl_bt_rtos_init();
+#if !RS91X_BLE_ENABLE
+     sl_bt_rtos_init();
+#endif
 }
 
 void sl_internal_app_init(void) { }

--- a/matter/efr32/efr32mg24/BRD4186A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg24/BRD4186A/autogen/sl_event_handler.c
@@ -81,7 +81,9 @@ void sl_stack_init(void)
 {
   sl_rail_util_pa_init();
   sl_rail_util_pti_init();
-  sl_bt_rtos_init();
+#if !RS91X_BLE_ENABLE
+     sl_bt_rtos_init();
+#endif
 }
 
 void sl_internal_app_init(void) {}

--- a/matter/efr32/efr32mg24/BRD4187A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg24/BRD4187A/autogen/sl_event_handler.c
@@ -82,7 +82,9 @@ void sl_stack_init(void)
 {
   sl_rail_util_pa_init();
   sl_rail_util_pti_init();
-  sl_bt_rtos_init();
+#if !RS91X_BLE_ENABLE
+     sl_bt_rtos_init();
+#endif
 }
 
 void sl_internal_app_init(void)


### PR DESCRIPTION
Problem
What is being fixed? Examples:
Earlier all the applications use EFR32 BLE with RS9116 boards.

Change Overview
In this PR, we enabled RS9116 BLE for all the applications.

Testing
Tested manually by using MG12+RS9116
Tested manually by using MG24+RS9116