### PR TITLE
SiWx917 SoC -Increasing the nvm page size for 917 SoC

### DIFF
--- a/platform/emdrv/nvm3/src/nvm3_hal_flash_ccp.c
+++ b/platform/emdrv/nvm3/src/nvm3_hal_flash_ccp.c
@@ -114,7 +114,7 @@ static Ecode_t nvm3_halFlashGetInfo(nvm3_HalInfo_t *halInfo) {
   halInfo->deviceFamilyPartNumber = 19;
   halInfo->writeSize = 1;
   halInfo->memoryMapped = 1;
-  halInfo->pageSize = 1024;
+  halInfo->pageSize = 2048;
   halInfo->systemUnique = 0;
   return ECODE_NVM3_OK;
 }


### PR DESCRIPTION
#### Problem / Feature
nvm3 open was failing for 40k nvm3 size due to incorrect page size for 917 SoC

#### Change overview
Increased the page size from 1024 to 2048 (Matching to efr32 nvm page size)
halInfo->pageSize = 2048;

#### Testing
*Tested locally (917 SoC)