### PR TITLE
[Silabs]fixing the pins for mg12 boards

### DIFF
--- a/matter/efr32/efr32mg12/BRD4161A/config/brd4161a.h
+++ b/matter/efr32/efr32mg12/BRD4161A/config/brd4161a.h
@@ -1,14 +1,25 @@
 #ifndef _BRD4161A_H_
 #define _BRD4161A_H_
+
 #ifndef LOGGING_STATS
-#define WAKE_INDICATOR_PIN PIN(D, 3)
-#endif
+#ifdef EXP_BOARD
+#define WAKE_INDICATOR_PIN PIN(D, 10)
+#else
+#define WAKE_INDICATOR_PIN PIN(D, 11)
+#endif /* EXP_BOARD */
+#endif /* LOGGING_STATS */
 
 #ifdef LOGGING_STATS
-#define LOGGING_WAKE_INDICATOR_PIN PIN(D, 3)
+#ifdef EXP_BOARD
+#define LOGGING_WAKE_INDICATOR_PIN PIN(D, 10)
 #define LOGGING_STATS_PORT gpioPortD
-#define LOGGING_STATS_PIN 03
-#endif
+#define LOGGING_STATS_PIN 10
+#else
+#define LOGGING_WAKE_INDICATOR_PIN PIN(D, 11)
+#define LOGGING_STATS_PORT gpioPortD
+#define LOGGING_STATS_PIN 11
+#endif /* EXP_BOARD */
+#endif /* LOGGING_STAT */
 
 #define MY_USART USART2
 #define MY_USART_TX_SIGNAL dmadrvPeripheralSignal_USART2_TXBL
@@ -18,7 +29,11 @@
 #ifdef RS911X_WIFI
 #define WFX_RESET_PIN     PIN(D, 12)
 #define WFX_INTERRUPT_PIN PIN(C, 9)
-#define WFX_SLEEP_CONFIRM_PIN      PIN(D, 13)
+#ifdef EXP_BOARD
+#define WFX_SLEEP_CONFIRM_PIN PIN(D, 10) /* Exp hdr 7 */
+#else
+#define WFX_SLEEP_CONFIRM_PIN PIN(D, 11) /* Exp hdr 7 */
+#endif /* EXP_BOARD */
 #define SL_WFX_HOST_PINOUT_SPI_IRQ 9
 #else /* WF200 */
 #define SL_WFX_HOST_PINOUT_RESET_PORT gpioPortD


### PR DESCRIPTION
Correcting the sleepy pins on MG12
However it is not required for SMG since we are not supporting sleepy for mg12 boards but still good to have correct one
