### PR TITLE
Initialize NVM in sl_platform_init()

### DIFF
--- a/matter/efr32/efr32mg12/BRD4161A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4161A/autogen/sl_event_handler.c
@@ -15,6 +15,7 @@
 #include "sl_hfxo_manager.h"
 #include "sl_rail_util_pti.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_simple_button_instances.h"
 #include "sl_simple_led_instances.h"
 #include "sl_sleeptimer.h"
@@ -48,6 +49,7 @@ void sl_platform_init(void)
     sl_device_init_emu();
     sl_board_init();
     osKernelInitialize();
+    nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
     sl_power_manager_init();
 #endif

--- a/matter/efr32/efr32mg12/BRD4162A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4162A/autogen/sl_event_handler.c
@@ -12,6 +12,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -50,6 +51,7 @@ void sl_platform_init(void)
   sl_device_init_emu();
   sl_board_init();
   osKernelInitialize();
+  nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
   sl_power_manager_init();
 #endif

--- a/matter/efr32/efr32mg12/BRD4163A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4163A/autogen/sl_event_handler.c
@@ -12,6 +12,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -47,6 +48,7 @@ void sl_platform_init(void)
     sl_device_init_emu();
     sl_board_init();
     osKernelInitialize();
+    nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
     sl_power_manager_init();
 #endif

--- a/matter/efr32/efr32mg12/BRD4164A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4164A/autogen/sl_event_handler.c
@@ -12,6 +12,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -46,6 +47,7 @@ void sl_platform_init(void)
     sl_device_init_emu();
     sl_board_init();
     osKernelInitialize();
+    nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
     sl_power_manager_init();
 #endif

--- a/matter/efr32/efr32mg12/BRD4166A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4166A/autogen/sl_event_handler.c
@@ -12,6 +12,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -41,6 +42,7 @@ void sl_platform_init(void)
     sl_device_init_emu();
     sl_board_init();
     osKernelInitialize();
+    nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
     sl_power_manager_init();
 #endif

--- a/matter/efr32/efr32mg12/BRD4170A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4170A/autogen/sl_event_handler.c
@@ -12,6 +12,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -46,6 +47,7 @@ void sl_platform_init(void)
     sl_device_init_emu();
     sl_board_init();
     osKernelInitialize();
+    nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
     sl_power_manager_init();
 #endif

--- a/matter/efr32/efr32mg12/BRD4304A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg12/BRD4304A/autogen/sl_event_handler.c
@@ -12,6 +12,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -41,6 +42,7 @@ void sl_platform_init(void)
     sl_device_init_emu();
     sl_board_init();
     osKernelInitialize();
+    nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
     sl_power_manager_init();
 #endif

--- a/matter/efr32/efr32mg24/BRD2601B/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg24/BRD2601B/autogen/sl_event_handler.c
@@ -14,6 +14,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -48,6 +49,7 @@ void sl_platform_init(void)
   sl_device_init_emu();
   sl_board_init();
   osKernelInitialize();
+  nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
   sl_power_manager_init();
 #endif

--- a/matter/efr32/efr32mg24/BRD2703A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg24/BRD2703A/autogen/sl_event_handler.c
@@ -14,6 +14,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -43,6 +44,7 @@ void sl_platform_init(void)
     sl_device_init_emu();
     sl_board_init();
     osKernelInitialize();
+    nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
     sl_power_manager_init();
 #endif

--- a/matter/efr32/efr32mg24/BRD4186A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg24/BRD4186A/autogen/sl_event_handler.c
@@ -15,6 +15,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -48,6 +49,7 @@ void sl_platform_init(void)
     sl_device_init_emu();
     sl_board_init();
     osKernelInitialize();
+    nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
     sl_power_manager_init();
 #endif

--- a/matter/efr32/efr32mg24/BRD4186C/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg24/BRD4186C/autogen/sl_event_handler.c
@@ -15,6 +15,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -55,6 +56,7 @@ void sl_platform_init(void)
   sl_device_init_emu();
   sl_board_init();
   osKernelInitialize();
+  nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
   sl_power_manager_init();
 #endif

--- a/matter/efr32/efr32mg24/BRD4187A/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg24/BRD4187A/autogen/sl_event_handler.c
@@ -15,6 +15,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -49,6 +50,7 @@ void sl_platform_init(void)
   sl_device_init_emu();
   sl_board_init();
   osKernelInitialize();
+  nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
   sl_power_manager_init();
 #endif

--- a/matter/efr32/efr32mg24/BRD4187C/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg24/BRD4187C/autogen/sl_event_handler.c
@@ -15,6 +15,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -55,6 +56,7 @@ void sl_platform_init(void)
   sl_device_init_emu();
   sl_board_init();
   osKernelInitialize();
+  nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
   sl_power_manager_init();
 #endif

--- a/matter/efr32/mgm24/BRD2704A/autogen/sl_event_handler.c
+++ b/matter/efr32/mgm24/BRD2704A/autogen/sl_event_handler.c
@@ -18,6 +18,7 @@
 #include "btl_interface.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "sl_debug_swo.h"
 #include "gpiointerrupt.h"
@@ -47,8 +48,8 @@ void sl_platform_init(void)
   sl_device_init_emu();
   sl_board_init();
   bootloader_init();
-  nvm3_initDefault();
   osKernelInitialize();
+  nvm3_initDefault();
   sl_power_manager_init();
 }
 

--- a/matter/efr32/mgm24/BRD4316A/autogen/sl_event_handler.c
+++ b/matter/efr32/mgm24/BRD4316A/autogen/sl_event_handler.c
@@ -14,6 +14,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -45,6 +46,7 @@ void sl_platform_init(void)
   sl_device_init_emu();
   sl_board_init();
   osKernelInitialize();
+  nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
   sl_power_manager_init();
 #endif

--- a/matter/efr32/mgm24/BRD4317A/autogen/sl_event_handler.c
+++ b/matter/efr32/mgm24/BRD4317A/autogen/sl_event_handler.c
@@ -14,6 +14,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -45,6 +46,7 @@ void sl_platform_init(void)
   sl_device_init_emu();
   sl_board_init();
   osKernelInitialize();
+  nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
   sl_power_manager_init();
 #endif // SL_CATALOG_POWER_MANAGER_PRESENT

--- a/matter/efr32/mgm24/BRD4318A/autogen/sl_event_handler.c
+++ b/matter/efr32/mgm24/BRD4318A/autogen/sl_event_handler.c
@@ -16,6 +16,7 @@
 #include "sl_rail_util_rssi.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 // #include "platform-efr32.h"
 #include "sl_sleeptimer.h"
 #include "sl_debug_swo.h"
@@ -46,8 +47,8 @@ void sl_platform_init(void)
   sl_device_init_clocks();
   sl_device_init_emu();
   sl_board_init();
-  nvm3_initDefault();
   osKernelInitialize();
+  nvm3_initDefault();
   sl_power_manager_init();
 }
 

--- a/matter/efr32/mgm24/BRD4319A/autogen/sl_event_handler.c
+++ b/matter/efr32/mgm24/BRD4319A/autogen/sl_event_handler.c
@@ -13,6 +13,7 @@
 #include "sl_rail_util_pti.h"
 #include "sl_board_control.h"
 #include "sl_bt_rtos_adaptation.h"
+#include "nvm3_default.h"
 #include "sl_sleeptimer.h"
 #include "gpiointerrupt.h"
 #include "sl_simple_button_instances.h"
@@ -40,6 +41,7 @@ void sl_platform_init(void)
   sl_device_init_emu();
   sl_board_init();
   osKernelInitialize();
+  nvm3_initDefault();
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
   sl_power_manager_init();
 #endif


### PR DESCRIPTION
#### Problem / Feature
Part of the fix for https://jira.silabs.com/browse/MATTER-1695 . 

#### Change overview
Moving NVM initialization to sl_platform_init(). A Matter CSA repo PR will move the initialization out of SilabsConfig::Init()

#### Testing
Verified that a lighting app on BRD4161A successfully boots with this and a corresponding change to SilabsConfig::Init()