### PR TITLE
Replace OT define with the correct define

### DIFF
--- a/matter/efr32/efr32mg12/BRD4161A/config/sl_mbedtls_config.h
+++ b/matter/efr32/efr32mg12/BRD4161A/config/sl_mbedtls_config.h
@@ -22,7 +22,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -36,7 +36,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/efr32mg12/BRD4162A/config/sl_mbedtls_config.h
+++ b/matter/efr32/efr32mg12/BRD4162A/config/sl_mbedtls_config.h
@@ -22,7 +22,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -36,7 +36,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/efr32mg12/BRD4163A/config/sl_mbedtls_config.h
+++ b/matter/efr32/efr32mg12/BRD4163A/config/sl_mbedtls_config.h
@@ -22,7 +22,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -36,7 +36,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/efr32mg12/BRD4164A/config/sl_mbedtls_config.h
+++ b/matter/efr32/efr32mg12/BRD4164A/config/sl_mbedtls_config.h
@@ -22,7 +22,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -36,7 +36,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/efr32mg12/BRD4166A/config/sl_mbedtls_config.h
+++ b/matter/efr32/efr32mg12/BRD4166A/config/sl_mbedtls_config.h
@@ -22,7 +22,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -36,7 +36,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/efr32mg12/BRD4170A/config/sl_mbedtls_config.h
+++ b/matter/efr32/efr32mg12/BRD4170A/config/sl_mbedtls_config.h
@@ -22,7 +22,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -36,7 +36,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/efr32mg12/BRD4304A/config/sl_mbedtls_config.h
+++ b/matter/efr32/efr32mg12/BRD4304A/config/sl_mbedtls_config.h
@@ -18,7 +18,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -28,7 +28,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/efr32mg24/BRD2601B/config/sl_mbedtls_config.h
+++ b/matter/efr32/efr32mg24/BRD2601B/config/sl_mbedtls_config.h
@@ -22,7 +22,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -36,7 +36,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/efr32mg24/BRD2703A/config/sl_mbedtls_config.h
+++ b/matter/efr32/efr32mg24/BRD2703A/config/sl_mbedtls_config.h
@@ -18,7 +18,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -28,7 +28,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/efr32mg24/BRD4186A/config/sl_mbedtls_config.h
+++ b/matter/efr32/efr32mg24/BRD4186A/config/sl_mbedtls_config.h
@@ -18,7 +18,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -28,7 +28,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/efr32mg24/BRD4186C/config/sl_mbedtls_config.h
+++ b/matter/efr32/efr32mg24/BRD4186C/config/sl_mbedtls_config.h
@@ -18,7 +18,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -28,7 +28,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/efr32mg24/BRD4187A/config/sl_mbedtls_config.h
+++ b/matter/efr32/efr32mg24/BRD4187A/config/sl_mbedtls_config.h
@@ -18,7 +18,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -28,7 +28,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/efr32mg24/BRD4187C/config/sl_mbedtls_config.h
+++ b/matter/efr32/efr32mg24/BRD4187C/config/sl_mbedtls_config.h
@@ -22,7 +22,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -36,7 +36,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/mgm24/BRD2704A/config/sl_mbedtls_config.h
+++ b/matter/efr32/mgm24/BRD2704A/config/sl_mbedtls_config.h
@@ -22,7 +22,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -36,7 +36,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/mgm24/BRD4316A/config/sl_mbedtls_config.h
+++ b/matter/efr32/mgm24/BRD4316A/config/sl_mbedtls_config.h
@@ -22,7 +22,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -36,7 +36,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/mgm24/BRD4317A/config/sl_mbedtls_config.h
+++ b/matter/efr32/mgm24/BRD4317A/config/sl_mbedtls_config.h
@@ -22,7 +22,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -36,7 +36,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/mgm24/BRD4318A/config/sl_mbedtls_config.h
+++ b/matter/efr32/mgm24/BRD4318A/config/sl_mbedtls_config.h
@@ -22,7 +22,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -36,7 +36,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/efr32/mgm24/BRD4319A/config/sl_mbedtls_config.h
+++ b/matter/efr32/mgm24/BRD4319A/config/sl_mbedtls_config.h
@@ -22,7 +22,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when receiving data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_IN_CONTENT_LEN 768
@@ -36,7 +36,7 @@
 // <i> Default: 768
 // <i> The size configured here determines the size of the internal I/O
 // <i> buffer used in mbedTLS when sending data.
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 900
 #else
 #define SL_MBEDTLS_SSL_OUT_CONTENT_LEN 768

--- a/matter/mbedtls/tinycrypt/inc/mbedtls/config.h
+++ b/matter/mbedtls/tinycrypt/inc/mbedtls/config.h
@@ -337,7 +337,7 @@ typedef void mbedtls_ecp_restart_ctx;
 #define MBEDTLS_ENTROPY_MAX_SOURCES                                            \
   2 /**< Maximum number of sources supported */
 #define MBEDTLS_SSL_DTLS_BADMAC_LIMIT
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#if SL_USE_COAP_CONFIG
 #define MBEDTLS_SSL_MAX_CONTENT_LEN                                            \
   900 /**< Maxium fragment length in bytes                                     \
        */


### PR DESCRIPTION
#### Problem / Feature
`OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE` shouldn't be used with the coap library.
Doesn't get set one the crypto files get compiled.

Use a configuration define to set correct configs