### PR TITLE
Build error fixed

### DIFF
--- a/matter/si91x/siwx917/BRD4325x/support/inc/system_si917.h
+++ b/matter/si91x/siwx917/BRD4325x/support/inc/system_si917.h
@@ -21,10 +21,14 @@
 extern "C" {
 #endif
 
-#include "cmsis_gcc.h"
-#include "core_cm4.h" /* Cortex-M4 processor and core peripherals */
+// system header
 #include "si91x_device.h"
+// Processor spefic haeders
+#include "core_cm4.h" /* Cortex-M4 processor and core peripherals */
 #include <stdint.h>
+
+// CMSIS GCC header
+#include "cmsis_gcc.h"
 
 /*******************************************************************************
  * @addtogroup Parts

--- a/matter/si91x/siwx917/BRD4325x/support/src/startup_common_RS1xxxx.c
+++ b/matter/si91x/siwx917/BRD4325x/support/src/startup_common_RS1xxxx.c
@@ -14,10 +14,12 @@
  *            priority is Privileged, and the Stack is set to Main.
  *******************************************************************************
  */
-#include "core_cm4.h"
-#include "rsi_ps_ram_func.h"
+// System headers
 #include "si91x_device.h"
 #include "system_si91x.h"
+// Processor specific headers
+#include "core_cm4.h"
+#include "rsi_ps_ram_func.h"
 /*----------Stack Symbols-----------------------------------------------*/
 extern uint32_t __StackTop;
 extern uint32_t __co_stackTop;


### PR DESCRIPTION
Restyler changed the order of header files which was causing build issues.

Fixed the order of header files