### PR TITLE
Ports NVIC API from autogenerated files for WiseConnect 3.0.13

### DIFF
--- a/matter/si91x/siwx917/BRD4325x/autogen/sl_event_handler.c
+++ b/matter/si91x/siwx917/BRD4325x/autogen/sl_event_handler.c
@@ -5,10 +5,12 @@
 #include "rsi_chip.h"
 #include "rsi_wisemcu_hardware_setup.h"
 #include "sli_siwx917_soc.h"
+#include "sl_device_init_nvic.h"
 
 void sl_platform_init(void) {
   SystemCoreClockUpdate();
   sli_si91x_platform_init();
+  sl_device_init_nvic();
   RSI_Board_Init();
   sl_si91x_hardware_setup();
   osKernelInitialize();


### PR DESCRIPTION
#### Problem / Feature
* Synchronize the autogen file(s) for WiseConnect 3.0.13

#### Change overview
* Updates autogen files to reflect NVIC API changes for WiseConnect 3.0.13

#### Testing
* >If manually tested, what platforms controller and device platforms were manually tested, and how?

Tested manually for sanity on BRD4325B (DUAL FLASH) and BRD4388 (COMMON FLASH)