### PR TITLE
Fix Shell for MG24 by modifying flow control configs

### DIFF
--- a/matter/efr32/efr32mg24/BRD2703A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/efr32mg24/BRD2703A/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/efr32mg24/BRD4186A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/efr32mg24/BRD4186A/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/efr32mg24/BRD4186C/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/efr32mg24/BRD4186C/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/efr32mg24/BRD4187A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/efr32mg24/BRD4187A/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/efr32mg24/BRD4187C/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/efr32mg24/BRD4187C/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/mgm24/BRD4316A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/mgm24/BRD4316A/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/mgm24/BRD4317A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/mgm24/BRD4317A/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/mgm24/BRD4318A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/mgm24/BRD4318A/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/mgm24/BRD4319A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/mgm24/BRD4319A/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling


### PR DESCRIPTION
#### Problem / Feature
Some boards had Hw flow control configured when we don't use flow control for the shells.

#### Change overview
Change flow control config to none

#### Testing
Manual tests with BRD4187C