### PR TITLE
Update VCOM configurations to remove Flow Control

### DIFF
--- a/matter/efr32/efr32mg12/BRD4161A/config/sl_uartdrv_usart_vcom_config.h
+++ b/matter/efr32/efr32mg12/BRD4161A/config/sl_uartdrv_usart_vcom_config.h
@@ -60,7 +60,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_USART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_USART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_USART_VCOM_OVERSAMPLING> Oversampling selection
 // <usartOVS16=> 16x oversampling

--- a/matter/efr32/efr32mg12/BRD4163A/config/sl_uartdrv_usart_vcom_config.h
+++ b/matter/efr32/efr32mg12/BRD4163A/config/sl_uartdrv_usart_vcom_config.h
@@ -60,7 +60,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_USART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_USART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_USART_VCOM_OVERSAMPLING> Oversampling selection
 // <usartOVS16=> 16x oversampling

--- a/matter/efr32/efr32mg12/BRD4164A/config/sl_uartdrv_usart_vcom_config.h
+++ b/matter/efr32/efr32mg12/BRD4164A/config/sl_uartdrv_usart_vcom_config.h
@@ -60,7 +60,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_USART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_USART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_USART_VCOM_OVERSAMPLING> Oversampling selection
 // <usartOVS16=> 16x oversampling

--- a/matter/efr32/efr32mg12/BRD4304A/config/sl_uartdrv_usart_vcom_config.h
+++ b/matter/efr32/efr32mg12/BRD4304A/config/sl_uartdrv_usart_vcom_config.h
@@ -60,7 +60,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_USART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_USART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_USART_VCOM_OVERSAMPLING> Oversampling selection
 // <usartOVS16=> 16x oversampling

--- a/matter/efr32/efr32mg24/BRD2703A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/efr32mg24/BRD2703A/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/efr32mg24/BRD4186A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/efr32mg24/BRD4186A/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/efr32mg24/BRD4186C/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/efr32mg24/BRD4186C/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/efr32mg24/BRD4187A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/efr32mg24/BRD4187A/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/efr32mg24/BRD4187C/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/efr32mg24/BRD4187C/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/mgm24/BRD4316A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/mgm24/BRD4316A/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/mgm24/BRD4317A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/mgm24/BRD4317A/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/mgm24/BRD4318A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/mgm24/BRD4318A/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling

--- a/matter/efr32/mgm24/BRD4319A/config/sl_uartdrv_eusart_vcom_config.h
+++ b/matter/efr32/mgm24/BRD4319A/config/sl_uartdrv_eusart_vcom_config.h
@@ -65,7 +65,7 @@
 // <uartdrvFlowControlHw=> nRTS/nCTS hardware handshake
 // <uartdrvFlowControlHwUart=> UART peripheral controls nRTS/nCTS
 // <i> Default: uartdrvFlowControlHwUart
-#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlHwUart
+#define SL_UARTDRV_EUSART_VCOM_FLOW_CONTROL_TYPE uartdrvFlowControlNone
 
 // <o SL_UARTDRV_EUSART_VCOM_OVERSAMPLING> Oversampling selection
 // <eusartOVS16=> 16x oversampling


### PR DESCRIPTION
#### Problem / Feature
On some boards, flow control was configured to hardware when we do not use it for Matter shells

#### Change overview
Change VCOM config to not use flow control

#### Testing
Manual tests with BRD4187C, 86C and 2601B.