### PR TITLE
[WiFi] - Adds changes required for wifi-sdk 3.1.1

### DIFF
--- a/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c
+++ b/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c
@@ -18,7 +18,7 @@
 #include "rsi_pll.h"
 #include "rsi_rom_clks.h"
 #include "silabs_utils.h"
-#include "sl_si91x_button_config.h"
+#include "sl_si91x_button_pin_config.h"
 #include "sli_siwx917_soc.h"
 
 #define SOC_PLL_REF_FREQUENCY 32000000 /* PLL input REFERENCE clock 32MHZ */
@@ -87,6 +87,6 @@ int soc_pll_config(void) {
 
 void sl_si91x_button_isr(uint8_t pin, uint8_t state) {
   (pin == SL_BUTTON_BTN0_PIN)
-      ? sl_button_on_change(SL_BUTTON_BTN0_NUMBER, state)
-      : sl_button_on_change(SL_BUTTON_BTN1_NUMBER, state);
+      ? sl_button_on_change(SL_BUTTON_BTN0_NUMBER, !state)
+      : sl_button_on_change(SL_BUTTON_BTN1_NUMBER, !state);
 }


### PR DESCRIPTION
* Updated the header file name which renamed in wifi-sdk
* Updated the state changes for the button interrupts which were modified from wifi-sdk
> Now we are getting 0 on press and 1 on release from the interrupt