### PR TITLE
[SiWx917][Sleepy] Increase the ram retention from 256k to 320k

### DIFF
--- a/matter/si91x/siwx917/BRD4338A/support/src/sl_si91x_m4_ps.c
+++ b/matter/si91x/siwx917/BRD4338A/support/src/sl_si91x_m4_ps.c
@@ -315,7 +315,7 @@ void sl_si91x_m4_sleep_wakeup(void) {
   M4SS_P2P_INTR_SET_REG &= ~BIT(3);
 #endif
   /* Configure RAM Usage and Retention Size */
-  sl_si91x_configure_ram_retention(WISEMCU_256KB_RAM_IN_USE,
+  sl_si91x_configure_ram_retention(WISEMCU_320KB_RAM_IN_USE,
                                    WISEMCU_RETAIN_DEFAULT_RAM_DURING_SLEEP);
   /* Trigger M4 Sleep*/
   MCU_RET->NPSS_GPIO_CNTRL[0].NPSS_GPIO_CTRLS_b.NPSS_GPIO_OUT = 0;


### PR DESCRIPTION
#### Problem / Feature
The device was getting crashed after commissioning. The LWIP_PBUF_POOL size was increase from 16 to 32 in https://github.com/project-chip/connectedhomeip/commit/649e991b07f0d2f938168977069c01e8e617631e PR due to which we need to retain some extra RAM

#### Change overview
Increase the RAM retention from 256KB to 320KB, so that before going to sleep total Ram can be retained

#### Testing
Tested manually