### PR TITLE
PSA Crypto: Enabled compatibility with drivers V1 and V2.

### DIFF
--- a/matter/efr32/efr32mg12/BRD4161A/config/psa_crypto_config.h
+++ b/matter/efr32/efr32mg12/BRD4161A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/efr32mg12/BRD4162A/config/psa_crypto_config.h
+++ b/matter/efr32/efr32mg12/BRD4162A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/efr32mg12/BRD4163A/config/psa_crypto_config.h
+++ b/matter/efr32/efr32mg12/BRD4163A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/efr32mg12/BRD4164A/config/psa_crypto_config.h
+++ b/matter/efr32/efr32mg12/BRD4164A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/efr32mg12/BRD4166A/config/psa_crypto_config.h
+++ b/matter/efr32/efr32mg12/BRD4166A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/efr32mg12/BRD4170A/config/psa_crypto_config.h
+++ b/matter/efr32/efr32mg12/BRD4170A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/efr32mg12/BRD4304A/config/psa_crypto_config.h
+++ b/matter/efr32/efr32mg12/BRD4304A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/efr32mg24/BRD2601B/config/psa_crypto_config.h
+++ b/matter/efr32/efr32mg24/BRD2601B/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/efr32mg24/BRD2703A/config/psa_crypto_config.h
+++ b/matter/efr32/efr32mg24/BRD2703A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/efr32mg24/BRD4186A/config/psa_crypto_config.h
+++ b/matter/efr32/efr32mg24/BRD4186A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/efr32mg24/BRD4186C/config/psa_crypto_config.h
+++ b/matter/efr32/efr32mg24/BRD4186C/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/efr32mg24/BRD4187A/config/psa_crypto_config.h
+++ b/matter/efr32/efr32mg24/BRD4187A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/efr32mg24/BRD4187C/config/psa_crypto_config.h
+++ b/matter/efr32/efr32mg24/BRD4187C/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/mgm24/BRD2704A/config/psa_crypto_config.h
+++ b/matter/efr32/mgm24/BRD2704A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/mgm24/BRD4316A/config/psa_crypto_config.h
+++ b/matter/efr32/mgm24/BRD4316A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/mgm24/BRD4317A/config/psa_crypto_config.h
+++ b/matter/efr32/mgm24/BRD4317A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/mgm24/BRD4318A/config/psa_crypto_config.h
+++ b/matter/efr32/mgm24/BRD4318A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys

--- a/matter/efr32/mgm24/BRD4319A/config/psa_crypto_config.h
+++ b/matter/efr32/mgm24/BRD4319A/config/psa_crypto_config.h
@@ -56,7 +56,7 @@
 // <i> If no v1 files are used, its support can be disabled for space
 // <i> optimization.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V1_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V1_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V2_DRIVER> Enable V2 ITS Driver Support <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys
@@ -69,7 +69,7 @@
 // <i> driver before in GSDK 4.1.x and earlier, or the keys has been already
 // <i> migrated.
 // <i> Default: 0
-#define SL_PSA_ITS_SUPPORT_V2_DRIVER 0
+#define SL_PSA_ITS_SUPPORT_V2_DRIVER 1
 
 // <o SL_PSA_ITS_SUPPORT_V3_DRIVER> Enable support for V3 ITS Driver <0-1>
 // <i> Devices that have used GSDK 4.1.x and earlier, and used ITS have the keys


### PR DESCRIPTION
#### Problem / Feature
PSA crypt keys created with drivers V1+V2 cannot be used by applications running driver V3 alone. This causes Matter application to stop working when updated to latest GSDK.

#### Change overview
Drivers V1 and V2 enabled for all boards. This enables PSA to automatically upgrade old keys to V3.

#### Testing
Tested on EFR32MG12.