### PR TITLE
[SiWx917] Removing the register set from trigger sleep

### DIFF
--- a/matter/si91x/siwx917/BRD4338A/support/src/sl_si91x_m4_ps.c
+++ b/matter/si91x/siwx917/BRD4338A/support/src/sl_si91x_m4_ps.c
@@ -306,9 +306,6 @@ void sl_si91x_m4_sleep_wakeup(void) {
                          RSI_WAKEUP_WITH_RETENTION_WO_ULPSS_RAM);
 #else
 
-#ifdef SLI_SI91X_MCU_COMMON_FLASH_MODE
-  M4SS_P2P_INTR_SET_REG &= ~BIT(3);
-#endif
   /* Configure RAM Usage and Retention Size */
   sl_si91x_configure_ram_retention(WISEMCU_320KB_RAM_IN_USE,
                                    WISEMCU_RETAIN_DEFAULT_RAM_DURING_SLEEP);


### PR DESCRIPTION
#### Problem / Feature
Setting M4 P2P register was handled before calling in sleep, which is (wifi sdk 3.1.3) now handled in the sleep API itself 

#### Change overview
commenting the Register set

#### Testing
Tested locally