### PR TITLE
Add Null check for a function pointer that might not be set

### DIFF
--- a/matter/mbedtls/tinycrypt/src/pk.c
+++ b/matter/mbedtls/tinycrypt/src/pk.c
@@ -95,8 +95,9 @@ void mbedtls_pk_free(mbedtls_pk_context *ctx) {
   if (ctx == NULL)
     return;
 
-  if (ctx->pk_info != NULL)
+  if ((ctx->pk_info != NULL) && (ctx->pk_info->ctx_free_func != NULL)) {
     ctx->pk_info->ctx_free_func(ctx->pk_ctx);
+  }
 
   mbedtls_platform_zeroize(ctx, sizeof(mbedtls_pk_context));
 }


### PR DESCRIPTION
It is possible that the pkinfo of the used pk context is uninitialized. Add a check to make sure it has a free function before calling it

this fixes MATTER-3426 in the context of provisioned certificates