### PR TITLE
[SiWx917] Added fixes for 917 SoC timer issue 

### DIFF
--- a/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c
+++ b/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c
@@ -23,7 +23,7 @@
 #include "rsi_debug.h"
 #include "rsi_rom_egpio.h"
 
-#define SOC_PLL_REF_FREQUENCY 40000000// /* PLL input REFERENCE clock 32MHZ */
+#define SOC_PLL_REF_FREQUENCY 40000000 // /* PLL input REFERENCE clock 40MHZ */
 
 // Note: Change this macro to required PLL frequency in hertz
 #define PS4_SOC_FREQ 180000000 /* PLL out clock 180MHz */
@@ -33,29 +33,30 @@
 
 /* QSPI clock config params */
 #define INTF_PLL_500_CTRL_VALUE 0xD900
-#define INTF_PLL_CLK 80000000 /* PLL out clock 80 MHz */
+#define INTF_PLL_CLK            80000000 /* PLL out clock 80 MHz */
 
-#define PMU_GOOD_TIME 31  /*Duration in us*/
+#define PMU_GOOD_TIME  31 /*Duration in us*/
 #define XTAL_GOOD_TIME 31 /*Duration in us*/
 
 /*Pre-fetch and regestring */
-#define ICACHE2_ADDR_TRANSLATE_1_REG *(volatile uint32_t *)(0x20280000 + 0x24)
+#define ICACHE2_ADDR_TRANSLATE_1_REG  *(volatile uint32_t *)(0x20280000 + 0x24)
 #define MISC_CFG_SRAM_REDUNDANCY_CTRL *(volatile uint32_t *)(0x46008000 + 0x18)
-#define MISC_CONFIG_MISC_CTRL1 *(volatile uint32_t *)(0x46008000 + 0x44)
-#define MISC_QUASI_SYNC_MODE *(volatile uint32_t *)(0x46008000 + 0x84)
+#define MISC_CONFIG_MISC_CTRL1        *(volatile uint32_t *)(0x46008000 + 0x44)
+#define MISC_QUASI_SYNC_MODE          *(volatile uint32_t *)(0x46008000 + 0x84)
 
 void sl_button_on_change(uint8_t btn, uint8_t btnAction);
 
-int soc_pll_config(void) {
+int soc_pll_config(void)
+{
   int32_t status = RSI_OK;
 
   RSI_CLK_M4SocClkConfig(M4CLK, M4_ULPREFCLK, 0);
-    // Configures the required registers for 180 Mhz clock in PS4
+  // Configures the required registers for 180 Mhz clock in PS4
   RSI_PS_PS4SetRegisters();
-    // Configure the PLL frequency
-    // Configure the SOC PLL to 180MHz
+  // Configure the PLL frequency
+  // Configure the SOC PLL to 180MHz
   RSI_CLK_SetSocPllFreq(M4CLK, PS4_SOC_FREQ, SOC_PLL_REF_FREQUENCY);
-    // Switch M4 clock to PLL clock for speed operations
+  // Switch M4 clock to PLL clock for speed operations
   RSI_CLK_M4SocClkConfig(M4CLK, M4_SOCPLLCLK, 0);
 
   SysTick_Config(SystemCoreClock / 1000);
@@ -64,7 +65,7 @@ int soc_pll_config(void) {
 #ifdef SWITCH_QSPI_TO_SOC_PLL
   /* program intf pll to 160Mhz */
   SPI_MEM_MAP_PLL(INTF_PLL_500_CTRL_REG9) = INTF_PLL_500_CTRL_VALUE;
-  status = RSI_CLK_SetIntfPllFreq(M4CLK, INTF_PLL_CLK, SOC_PLL_REF_FREQUENCY);
+  status                                  = RSI_CLK_SetIntfPllFreq(M4CLK, INTF_PLL_CLK, SOC_PLL_REF_FREQUENCY);
   if (status != RSI_OK) {
     SILABS_LOG("Failed to Config Interface PLL Clock, status:%d", status);
   } else {
@@ -76,8 +77,8 @@ int soc_pll_config(void) {
   return 0;
 }
 
-void sl_si91x_button_isr(uint8_t pin, uint8_t state) {
-  (pin == SL_BUTTON_BTN0_PIN)
-      ? sl_button_on_change(SL_BUTTON_BTN0_NUMBER, !state)
-      : sl_button_on_change(SL_BUTTON_BTN1_NUMBER, !state);
+void sl_si91x_button_isr(uint8_t pin, uint8_t state)
+{
+  (pin == SL_BUTTON_BTN0_PIN) ? sl_button_on_change(SL_BUTTON_BTN0_NUMBER, !state)
+                              : sl_button_on_change(SL_BUTTON_BTN1_NUMBER, !state);
 }

--- a/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c
+++ b/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c
@@ -18,7 +18,6 @@
 #include "rsi_debug.h"
 #include "rsi_pll.h"
 #include "rsi_rom_clks.h"
-#include "rsi_rom_egpio.h"
 #include "silabs_utils.h"
 #include "sl_si91x_button_pin_config.h"
 #include "sli_siwx917_soc.h"

--- a/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c
+++ b/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c
@@ -20,8 +20,9 @@
 #include "silabs_utils.h"
 #include "sl_si91x_button_pin_config.h"
 #include "sli_siwx917_soc.h"
+#include "rsi_debug.h"
 
-#define SOC_PLL_REF_FREQUENCY 32000000 /* PLL input REFERENCE clock 32MHZ */
+#define SOC_PLL_REF_FREQUENCY 40000000//32000000 /* PLL input REFERENCE clock 32MHZ */
 
 // Note: Change this macro to required PLL frequency in hertz
 #define PS4_SOC_FREQ 180000000 /* PLL out clock 180MHz */
@@ -69,6 +70,9 @@ int soc_pll_config(void) {
 
   RSI_CLK_M4SocClkConfig(M4CLK, M4_SOCPLLCLK, 0);
 
+  SysTick_Config(SystemCoreClock / 1000);
+  DEBUGINIT();
+
 #ifdef SWITCH_QSPI_TO_SOC_PLL
   /* program intf pll to 160Mhz */
   SPI_MEM_MAP_PLL(INTF_PLL_500_CTRL_REG9) = INTF_PLL_500_CTRL_VALUE;
@@ -81,7 +85,6 @@ int soc_pll_config(void) {
 
   RSI_CLK_QspiClkConfig(M4CLK, QSPI_INTFPLLCLK, 0, 0, 1);
 #endif /* SWITCH_QSPI_TO_SOC_PLL */
-
   return 0;
 }
 

--- a/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c
+++ b/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c
@@ -15,13 +15,13 @@
  *    limitations under the License.
  */
 
+#include "rsi_debug.h"
 #include "rsi_pll.h"
 #include "rsi_rom_clks.h"
+#include "rsi_rom_egpio.h"
 #include "silabs_utils.h"
 #include "sl_si91x_button_pin_config.h"
 #include "sli_siwx917_soc.h"
-#include "rsi_debug.h"
-#include "rsi_rom_egpio.h"
 
 #define SOC_PLL_REF_FREQUENCY 40000000 // /* PLL input REFERENCE clock 40MHZ */
 
@@ -33,21 +33,20 @@
 
 /* QSPI clock config params */
 #define INTF_PLL_500_CTRL_VALUE 0xD900
-#define INTF_PLL_CLK            80000000 /* PLL out clock 80 MHz */
+#define INTF_PLL_CLK 80000000 /* PLL out clock 80 MHz */
 
-#define PMU_GOOD_TIME  31 /*Duration in us*/
+#define PMU_GOOD_TIME 31  /*Duration in us*/
 #define XTAL_GOOD_TIME 31 /*Duration in us*/
 
 /*Pre-fetch and regestring */
-#define ICACHE2_ADDR_TRANSLATE_1_REG  *(volatile uint32_t *)(0x20280000 + 0x24)
+#define ICACHE2_ADDR_TRANSLATE_1_REG *(volatile uint32_t *)(0x20280000 + 0x24)
 #define MISC_CFG_SRAM_REDUNDANCY_CTRL *(volatile uint32_t *)(0x46008000 + 0x18)
-#define MISC_CONFIG_MISC_CTRL1        *(volatile uint32_t *)(0x46008000 + 0x44)
-#define MISC_QUASI_SYNC_MODE          *(volatile uint32_t *)(0x46008000 + 0x84)
+#define MISC_CONFIG_MISC_CTRL1 *(volatile uint32_t *)(0x46008000 + 0x44)
+#define MISC_QUASI_SYNC_MODE *(volatile uint32_t *)(0x46008000 + 0x84)
 
 void sl_button_on_change(uint8_t btn, uint8_t btnAction);
 
-int soc_pll_config(void)
-{
+int soc_pll_config(void) {
   int32_t status = RSI_OK;
 
   RSI_CLK_M4SocClkConfig(M4CLK, M4_ULPREFCLK, 0);
@@ -65,7 +64,7 @@ int soc_pll_config(void)
 #ifdef SWITCH_QSPI_TO_SOC_PLL
   /* program intf pll to 160Mhz */
   SPI_MEM_MAP_PLL(INTF_PLL_500_CTRL_REG9) = INTF_PLL_500_CTRL_VALUE;
-  status                                  = RSI_CLK_SetIntfPllFreq(M4CLK, INTF_PLL_CLK, SOC_PLL_REF_FREQUENCY);
+  status = RSI_CLK_SetIntfPllFreq(M4CLK, INTF_PLL_CLK, SOC_PLL_REF_FREQUENCY);
   if (status != RSI_OK) {
     SILABS_LOG("Failed to Config Interface PLL Clock, status:%d", status);
   } else {
@@ -77,8 +76,8 @@ int soc_pll_config(void)
   return 0;
 }
 
-void sl_si91x_button_isr(uint8_t pin, uint8_t state)
-{
-  (pin == SL_BUTTON_BTN0_PIN) ? sl_button_on_change(SL_BUTTON_BTN0_NUMBER, !state)
-                              : sl_button_on_change(SL_BUTTON_BTN1_NUMBER, !state);
+void sl_si91x_button_isr(uint8_t pin, uint8_t state) {
+  (pin == SL_BUTTON_BTN0_PIN)
+      ? sl_button_on_change(SL_BUTTON_BTN0_NUMBER, !state)
+      : sl_button_on_change(SL_BUTTON_BTN1_NUMBER, !state);
 }

--- a/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c
+++ b/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c
@@ -21,8 +21,9 @@
 #include "sl_si91x_button_pin_config.h"
 #include "sli_siwx917_soc.h"
 #include "rsi_debug.h"
+#include "rsi_rom_egpio.h"
 
-#define SOC_PLL_REF_FREQUENCY 40000000//32000000 /* PLL input REFERENCE clock 32MHZ */
+#define SOC_PLL_REF_FREQUENCY 40000000// /* PLL input REFERENCE clock 32MHZ */
 
 // Note: Change this macro to required PLL frequency in hertz
 #define PS4_SOC_FREQ 180000000 /* PLL out clock 180MHz */
@@ -48,26 +49,13 @@ void sl_button_on_change(uint8_t btn, uint8_t btnAction);
 int soc_pll_config(void) {
   int32_t status = RSI_OK;
 
-  RSI_CLK_SocPllLockConfig(1, 1, 7);
-
-  RSI_CLK_SocPllRefClkConfig(2);
-
   RSI_CLK_M4SocClkConfig(M4CLK, M4_ULPREFCLK, 0);
-
-  /*Enable fre-fetch and register if SOC-PLL frequency is more than or equal to
-   * 120M*/
-#if (PS4_SOC_FREQ >= 120000000)
-  ICACHE2_ADDR_TRANSLATE_1_REG = BIT(21);
-  MISC_CFG_SRAM_REDUNDANCY_CTRL = BIT(4);
-  MISC_CONFIG_MISC_CTRL1 |= BIT(4);
-#if !(defined WISE_AOC_4)
-  MISC_QUASI_SYNC_MODE |= BIT(6);
-  MISC_QUASI_SYNC_MODE |= (BIT(6) | BIT(7));
-#endif /* !WISE_AOC_4 */
-#endif /* (PS4_SOC_FREQ > 120000000) */
-
+    // Configures the required registers for 180 Mhz clock in PS4
+  RSI_PS_PS4SetRegisters();
+    // Configure the PLL frequency
+    // Configure the SOC PLL to 180MHz
   RSI_CLK_SetSocPllFreq(M4CLK, PS4_SOC_FREQ, SOC_PLL_REF_FREQUENCY);
-
+    // Switch M4 clock to PLL clock for speed operations
   RSI_CLK_M4SocClkConfig(M4CLK, M4_SOCPLLCLK, 0);
 
   SysTick_Config(SystemCoreClock / 1000);


### PR DESCRIPTION
Problem / Feature
Timers are inconsistent with non-sleepy applications

Change overview
With non-sleepy applications ,RTOS Software Timer drift while using an RC-32MHz as a Core reference Clock. It has been changed to 40MHZ and timers are working accurately

Testing
Tested manually Tc-su_2_01 step 2, tc_su_2_02 step 2, tc_su_2_05 step 3 and tc_su_2_05 step 4