### PR TITLE
Reverting M4 clock to 32mhz RC clock as XTAL clock is used by TA

### DIFF
--- a/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c
+++ b/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c
@@ -22,7 +22,8 @@
 #include "sl_si91x_button_pin_config.h"
 #include "sli_siwx917_soc.h"
 
-#define SOC_PLL_REF_FREQUENCY 40000000 // /* PLL input REFERENCE clock 40MHZ */
+//As XTALclock  is used by TA and M4 can not access to the XTAL clock so m4 is moving to RC 32MHZ. 
+#define SOC_PLL_REF_FREQUENCY 32000000 // /* PLL input REFERENCE clock 32MHZ */
 
 // Note: Change this macro to required PLL frequency in hertz
 #define PS4_SOC_FREQ 180000000 /* PLL out clock 180MHz */


### PR DESCRIPTION
#### Problem / Feature
As XTALclock  is used by TA and M4 cannot access to this clock and Firmware changes already added as part of wifi_sdk

#### Change overview
moving M4 clock from XTAL clock to RC 32MHZ

#### Testing
commissioning and verified OTA delay timer test cases.
