### PR TITLE
Fix OT Cli init and Power Manager req

### DIFF
--- a/matter/efr32/efr32mg24/BRD2601B/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/efr32mg24/BRD2601B/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/efr32mg24/BRD2601B/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg24/BRD2601B/autogen/sl_ot_init.c
@@ -29,11 +29,17 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/efr32mg24/BRD2601B/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg24/BRD2601B/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);

--- a/matter/efr32/efr32mg24/BRD2703A/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/efr32mg24/BRD2703A/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/efr32mg24/BRD2703A/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg24/BRD2703A/autogen/sl_ot_init.c
@@ -29,11 +29,17 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/efr32mg24/BRD2703A/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg24/BRD2703A/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);

--- a/matter/efr32/efr32mg24/BRD4186A/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/efr32mg24/BRD4186A/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/efr32mg24/BRD4186A/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg24/BRD4186A/autogen/sl_ot_init.c
@@ -29,11 +29,17 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/efr32mg24/BRD4186A/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg24/BRD4186A/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);

--- a/matter/efr32/efr32mg24/BRD4186C/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/efr32mg24/BRD4186C/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/efr32mg24/BRD4186C/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg24/BRD4186C/autogen/sl_ot_init.c
@@ -29,11 +29,17 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/efr32mg24/BRD4186C/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg24/BRD4186C/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);

--- a/matter/efr32/efr32mg24/BRD4187A/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/efr32mg24/BRD4187A/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/efr32mg24/BRD4187A/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg24/BRD4187A/autogen/sl_ot_init.c
@@ -29,11 +29,17 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/efr32mg24/BRD4187A/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg24/BRD4187A/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);

--- a/matter/efr32/efr32mg24/BRD4187C/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/efr32mg24/BRD4187C/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/efr32mg24/BRD4187C/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg24/BRD4187C/autogen/sl_ot_init.c
@@ -29,11 +29,18 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);  
+
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/efr32mg24/BRD4187C/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg24/BRD4187C/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);  

--- a/matter/efr32/efr32mg26/BRD2608A/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/efr32mg26/BRD2608A/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/efr32mg26/BRD2608A/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg26/BRD2608A/autogen/sl_ot_init.c
@@ -29,11 +29,17 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/efr32mg26/BRD2608A/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg26/BRD2608A/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);

--- a/matter/efr32/efr32mg26/BRD4116A/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/efr32mg26/BRD4116A/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/efr32mg26/BRD4116A/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg26/BRD4116A/autogen/sl_ot_init.c
@@ -29,11 +29,17 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/efr32mg26/BRD4116A/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg26/BRD4116A/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);

--- a/matter/efr32/efr32mg26/BRD4117A/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/efr32mg26/BRD4117A/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/efr32mg26/BRD4117A/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg26/BRD4117A/autogen/sl_ot_init.c
@@ -29,11 +29,17 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/efr32mg26/BRD4117A/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg26/BRD4117A/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);

--- a/matter/efr32/efr32mg26/BRD4118A/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/efr32mg26/BRD4118A/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/efr32mg26/BRD4118A/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg26/BRD4118A/autogen/sl_ot_init.c
@@ -29,11 +29,17 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/efr32mg26/BRD4118A/autogen/sl_ot_init.c
+++ b/matter/efr32/efr32mg26/BRD4118A/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);

--- a/matter/efr32/mgm24/BRD2704A/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/mgm24/BRD2704A/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/mgm24/BRD2704A/autogen/sl_ot_init.c
+++ b/matter/efr32/mgm24/BRD2704A/autogen/sl_ot_init.c
@@ -29,11 +29,17 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/mgm24/BRD2704A/autogen/sl_ot_init.c
+++ b/matter/efr32/mgm24/BRD2704A/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);

--- a/matter/efr32/mgm24/BRD4316A/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/mgm24/BRD4316A/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/mgm24/BRD4316A/autogen/sl_ot_init.c
+++ b/matter/efr32/mgm24/BRD4316A/autogen/sl_ot_init.c
@@ -29,11 +29,17 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/mgm24/BRD4316A/autogen/sl_ot_init.c
+++ b/matter/efr32/mgm24/BRD4316A/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);

--- a/matter/efr32/mgm24/BRD4317A/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/mgm24/BRD4317A/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/mgm24/BRD4317A/autogen/sl_ot_init.c
+++ b/matter/efr32/mgm24/BRD4317A/autogen/sl_ot_init.c
@@ -29,11 +29,17 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/mgm24/BRD4317A/autogen/sl_ot_init.c
+++ b/matter/efr32/mgm24/BRD4317A/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);

--- a/matter/efr32/mgm24/BRD4318A/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/mgm24/BRD4318A/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/mgm24/BRD4318A/autogen/sl_ot_init.c
+++ b/matter/efr32/mgm24/BRD4318A/autogen/sl_ot_init.c
@@ -29,11 +29,17 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/mgm24/BRD4318A/autogen/sl_ot_init.c
+++ b/matter/efr32/mgm24/BRD4318A/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);

--- a/matter/efr32/mgm24/BRD4319A/autogen/sl_ot_custom_cli.c
+++ b/matter/efr32/mgm24/BRD4319A/autogen/sl_ot_custom_cli.c
@@ -57,5 +57,7 @@ const uint8_t sl_ot_custom_commands_count = OT_ARRAY_LENGTH(sl_ot_custom_command
 
 void sl_ot_custom_cli_init(void)
 {
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     IgnoreError(otCliSetUserCommands(sl_ot_custom_commands, sl_ot_custom_commands_count, NULL));
+#endif // CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 }

--- a/matter/efr32/mgm24/BRD4319A/autogen/sl_ot_init.c
+++ b/matter/efr32/mgm24/BRD4319A/autogen/sl_ot_init.c
@@ -29,11 +29,17 @@
  ******************************************************************************/
 
 #include "sl_ot_init.h"
+// TODO: Remove the Power Manager include when OT does not add an EM1 req at init
+#define CURRENT_MODULE_NAME "OPENTHREAD"
+#include "sl_power_manager.h"
 
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-  sl_ot_sleep_init();
+    sl_ot_sleep_init();  
+  
+  // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
   sl_ot_cli_init();
   sl_ot_custom_cli_init();
 }

--- a/matter/efr32/mgm24/BRD4319A/autogen/sl_ot_init.c
+++ b/matter/efr32/mgm24/BRD4319A/autogen/sl_ot_init.c
@@ -36,7 +36,7 @@
 void sl_ot_init(void)
 {
   sl_ot_create_instance();
-    sl_ot_sleep_init();  
+  sl_ot_sleep_init();  
   
   // TODO: Remove the Power Manager remove req when OT does not add an EM1 req at init
   sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);


### PR DESCRIPTION
#### Problem / Feature
* OT User CLI commands was getting init even if the OT cli was disable which caused an assert in the OT stack init
* OT adds an EM1 req in the sleepy which never gets removed

#### Change overview
* Ifdef guard the cli init
* Temporary remove the EM1 req until OT fixes its issue

#### Testing
* Manual tests 