### PR TITLE
Add include for user config as an SLC fix

### DIFF
--- a/matter/mbedtls/tinycrypt/inc/mbedtls/build_info.h
+++ b/matter/mbedtls/tinycrypt/inc/mbedtls/build_info.h
@@ -6,6 +6,10 @@
 // sl_mbedtls_config header. File keeps the previous logic by only including
 // check_config without needing to modfy the generated files.
 
+#if defined(MBEDTLS_USER_CONFIG_FILE)
+#include MBEDTLS_USER_CONFIG_FILE
+#endif
+
 #include <mbedtls/check_config.h>
 
 #endif /* MBEDTLS_BUILD_INFO_H */

--- a/matter/mbedtls/tinycrypt/inc/mbedtls/build_info.h
+++ b/matter/mbedtls/tinycrypt/inc/mbedtls/build_info.h
@@ -6,6 +6,7 @@
 // sl_mbedtls_config header. File keeps the previous logic by only including
 // check_config without needing to modfy the generated files.
 
+// SLC-FIX until we can use the generated si sdk components
 #if defined(MBEDTLS_USER_CONFIG_FILE)
 #include MBEDTLS_USER_CONFIG_FILE
 #endif


### PR DESCRIPTION
#### Problem / Feature
For SLC builds, we need a way to include the hardcoded mbedtls config without conflicting with the mbedtls config component. 

This define can be set by SLC to include it without affecting CSA builds that do not require this define.

#### Testing
Manual tests