### PR TITLE
Adds the BTN0 wakeup source for SiWx917

### DIFF
--- a/matter/si91x/siwx917/BRD4338A/autogen/sl_si91x_power_manager_wakeup_handler.c
+++ b/matter/si91x/siwx917/BRD4338A/autogen/sl_si91x_power_manager_wakeup_handler.c
@@ -31,7 +31,12 @@
 
 sl_status_t sl_si91x_power_manager_wakeup_init(void)
 {
-  sl_status_t status=SL_STATUS_OK;
+  sl_status_t status = SL_STATUS_OK;
+
+  status = sli_si91x_power_manager_gpio_init();
+  if (status != SL_STATUS_OK) {
+    return status;
+  }
   
   return status;
 }

--- a/matter/si91x/siwx917/BRD4338A/autogen/sl_si91x_power_manager_wakeup_handler.h
+++ b/matter/si91x/siwx917/BRD4338A/autogen/sl_si91x_power_manager_wakeup_handler.h
@@ -1,4 +1,4 @@
-/***************************************************************************//**
+/***************************************************************************/ /**
  * @file sl_si91x_power_manager_wakeup_handler.h.jinja
  * @brief Power Manager Service Wakeup Handler APIs
  *******************************************************************************
@@ -32,13 +32,12 @@
 
 #include "sl_status.h"
 
-
+#include "sl_si91x_driver_gpio.h"
 
 #include "sl_si91x_power_manager_wakeup_source_config.h"
 
-
 sl_status_t sl_si91x_power_manager_wakeup_init(void);
 
-
+sl_status_t sli_si91x_power_manager_gpio_init(void);
 
 #endif // SL_SI91X_POWER_MANAGER_WAKEUP_HANDLER_H

--- a/matter/si91x/siwx917/BRD4338A/config/sl_si91x_power_manager_wakeup_source_config.h
+++ b/matter/si91x/siwx917/BRD4338A/config/sl_si91x_power_manager_wakeup_source_config.h
@@ -59,7 +59,7 @@ extern "C" {
 // </e>
 
 // <e>GPIO Wakeup
-#define SL_ENABLE_GPIO_WAKEUP_SOURCE 0
+#define SL_ENABLE_GPIO_WAKEUP_SOURCE 1
 
 // <q ENABLE_NPSS_GPIO_0> Enable NPSS GPIO 0
 // <i> Default: 0
@@ -71,7 +71,7 @@ extern "C" {
 
 // <q ENABLE_NPSS_GPIO_2> Enable NPSS GPIO 2
 // <i> Default: 0
-#define ENABLE_NPSS_GPIO_2 0
+#define ENABLE_NPSS_GPIO_2 1
 
 // <q ENABLE_NPSS_GPIO_3> Enable NPSS GPIO 3
 // <i> Default: 0


### PR DESCRIPTION
#### Problem / Feature
* BTN0 is not working properly in sleep enabled applications.

#### Change overview
Adds the BTN0 as a wakeup source for sleep enabled applications on SiWx917

#### Testing
It was tested manually on the SiWx917 lock application.