### PR TITLE
Resolved init failure for 917NCP

### DIFF
--- a/components/service/network_manager/src/sl_net_for_lwip.c
+++ b/components/service/network_manager/src/sl_net_for_lwip.c
@@ -344,7 +344,9 @@ sl_status_t sl_net_wifi_client_init(sl_net_interface_t interface,
     return status;
   }
   wifi_client_context = context;
+#ifdef SLI_SI91X_MCU_INTERFACE
   tcpip_init(NULL, NULL);
+#endif // SLI_SI91X_MCU_INTERFACE
   sta_netif_config();
   return SL_STATUS_OK;
 }


### PR DESCRIPTION
#### Problem 
* Init failure is seen in 917NCP in ```sl_net_wifi_client_init``` API

#### Change overview

During init, the 917ncp is going into infinite loop inside tcpip_init() call. This tcpip_init() is called in InitChipStack ```PlatformManagerImpl::_InitChipStack(void)```
So removing this for 917ncp. 

#### Testing
How was this tested?
* Tested the build locally, init passed with this change.