### PR TITLE
Adds header to verify SL COMPONENT CATALOG

### DIFF
--- a/matter/si91x/support/hal/rsi_hal_mcu_m4.c
+++ b/matter/si91x/support/hal/rsi_hal_mcu_m4.c
@@ -19,6 +19,8 @@
 #include "rsi_pll.h"
 #include "rsi_rom_clks.h"
 #include "silabs_utils.h"
+#include "sl_component_catalog.h"
+
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 #include "sl_si91x_button_pin_config.h"
 #endif  //SL_CATALOG_SIMPLE_BUTTON_PRESENT


### PR DESCRIPTION
#### Problem / Feature
What is being fixed?
Add `sl_component_catalog.h` header to access SL_CATALOG_SIMPLE_BUTTON_PRESENT define.
