### PR TITLE
Updates for 917 ncp autogen files

### DIFF
--- a/matter/efr32/efr32mg24/BRD4186C/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg24/BRD4186C/autogen/sl_event_handler.c
@@ -71,10 +71,8 @@ void sl_kernel_start(void)
 void sl_driver_init(void)
 {
   sl_gpio_init();
-#ifndef SLI_SI917
 #ifdef SL_WIFI
   sl_spidrv_init_instances();
-#endif
 #endif
 #if defined(SL_MATTER_USE_SI70XX_SENSOR) && SL_MATTER_USE_SI70XX_SENSOR
   sl_i2cspm_init_instances();

--- a/matter/efr32/efr32mg24/BRD4186C/autogen/sl_spidrv_init.c
+++ b/matter/efr32/efr32mg24/BRD4186C/autogen/sl_spidrv_init.c
@@ -2,47 +2,49 @@
 #include "sl_spidrv_instances.h"
 #include "sl_assert.h"
 
-
-#ifdef RS911X_WIFI // EUSART is used in MG24 + RS9116 combination
+// EUSART is used in MG24 + RS9116 combination
+#ifdef RS911X_WIFI
+#if !(defined(EXP_BOARD) && EXP_BOARD)
 #include "sl_spidrv_eusart_exp_config.h"
 
 SPIDRV_HandleData_t sl_spidrv_eusart_exp_handle_data;
 SPIDRV_Handle_t sl_spidrv_eusart_exp_handle = &sl_spidrv_eusart_exp_handle_data;
 
 SPIDRV_Init_t sl_spidrv_eusart_init_exp = {
-  .port = SL_SPIDRV_EUSART_EXP_PERIPHERAL,
-  .portTx = SL_SPIDRV_EUSART_EXP_TX_PORT,
-  .portRx = SL_SPIDRV_EUSART_EXP_RX_PORT,
+  .port    = SL_SPIDRV_EUSART_EXP_PERIPHERAL,
+  .portTx  = SL_SPIDRV_EUSART_EXP_TX_PORT,
+  .portRx  = SL_SPIDRV_EUSART_EXP_RX_PORT,
   .portClk = SL_SPIDRV_EUSART_EXP_SCLK_PORT,
 #if defined(SL_SPIDRV_EUSART_EXP_CS_PORT)
   .portCs = SL_SPIDRV_EUSART_EXP_CS_PORT,
 #endif
-  .pinTx = SL_SPIDRV_EUSART_EXP_TX_PIN,
-  .pinRx = SL_SPIDRV_EUSART_EXP_RX_PIN,
+  .pinTx  = SL_SPIDRV_EUSART_EXP_TX_PIN,
+  .pinRx  = SL_SPIDRV_EUSART_EXP_RX_PIN,
   .pinClk = SL_SPIDRV_EUSART_EXP_SCLK_PIN,
 #if defined(SL_SPIDRV_EUSART_EXP_CS_PIN)
   .pinCs = SL_SPIDRV_EUSART_EXP_CS_PIN,
 #endif
-  .bitRate = SL_SPIDRV_EUSART_EXP_BITRATE,
-  .frameLength = SL_SPIDRV_EUSART_EXP_FRAME_LENGTH,
-  .dummyTxValue = 0,
-  .type = SL_SPIDRV_EUSART_EXP_TYPE,
-  .bitOrder = SL_SPIDRV_EUSART_EXP_BIT_ORDER,
-  .clockMode = SL_SPIDRV_EUSART_EXP_CLOCK_MODE,
-  .csControl = SL_SPIDRV_EUSART_EXP_CS_CONTROL,
+  .bitRate        = SL_SPIDRV_EUSART_EXP_BITRATE,
+  .frameLength    = SL_SPIDRV_EUSART_EXP_FRAME_LENGTH,
+  .dummyTxValue   = 0,
+  .type           = SL_SPIDRV_EUSART_EXP_TYPE,
+  .bitOrder       = SL_SPIDRV_EUSART_EXP_BIT_ORDER,
+  .clockMode      = SL_SPIDRV_EUSART_EXP_CLOCK_MODE,
+  .csControl      = SL_SPIDRV_EUSART_EXP_CS_CONTROL,
   .slaveStartMode = SL_SPIDRV_EUSART_EXP_SLAVE_START_MODE,
 };
 
-void sl_spidrv_init_instances(void) {
+void sl_spidrv_init_instances(void)
+{
 #if !defined(SL_SPIDRV_USART_EXP_CS_PIN)
   EFM_ASSERT(sl_spidrv_eusart_init_exp.csControl == spidrvCsControlAuto);
-#endif 
+#endif
   SPIDRV_Init(sl_spidrv_eusart_exp_handle, &sl_spidrv_eusart_init_exp);
 }
-
+#endif
 #endif
 
-#ifdef WF200_WIFI  // USART is used in MG24 + WF200 combination
+#if (WF200_WIFI | EXP_BOARD) // USART is used in MG24 + WF200 and MG24 + 917 NCP combination
 #include "sl_spidrv_exp_config.h"
 
 SPIDRV_HandleData_t sl_spidrv_exp_handle_data;
@@ -51,40 +53,41 @@ SPIDRV_Handle_t sl_spidrv_exp_handle = &sl_spidrv_exp_handle_data;
 SPIDRV_Init_t sl_spidrv_init_exp = {
   .port = SL_SPIDRV_EXP_PERIPHERAL,
 #if defined(_USART_ROUTELOC0_MASK)
-  .portLocationTx = SL_SPIDRV_EXP_TX_LOC,
-  .portLocationRx = SL_SPIDRV_EXP_RX_LOC,
+  .portLocationTx  = SL_SPIDRV_EXP_TX_LOC,
+  .portLocationRx  = SL_SPIDRV_EXP_RX_LOC,
   .portLocationClk = SL_SPIDRV_EXP_CLK_LOC,
 #if defined(SL_SPIDRV_EXP_CS_LOC)
   .portLocationCs = SL_SPIDRV_EXP_CS_LOC,
 #endif
 #elif defined(_GPIO_USART_ROUTEEN_MASK)
-  .portTx = SL_SPIDRV_EXP_TX_PORT,
-  .portRx = SL_SPIDRV_EXP_RX_PORT,
+  .portTx  = SL_SPIDRV_EXP_TX_PORT,
+  .portRx  = SL_SPIDRV_EXP_RX_PORT,
   .portClk = SL_SPIDRV_EXP_CLK_PORT,
 #if defined(SL_SPIDRV_EXP_CS_PORT)
-  .portCs = SL_SPIDRV_EXP_CS_PORT,
+  .portCs  = SL_SPIDRV_EXP_CS_PORT,
 #endif
-  .pinTx = SL_SPIDRV_EXP_TX_PIN,
-  .pinRx = SL_SPIDRV_EXP_RX_PIN,
-  .pinClk = SL_SPIDRV_EXP_CLK_PIN,
+  .pinTx   = SL_SPIDRV_EXP_TX_PIN,
+  .pinRx   = SL_SPIDRV_EXP_RX_PIN,
+  .pinClk  = SL_SPIDRV_EXP_CLK_PIN,
 #if defined(SL_SPIDRV_EXP_CS_PIN)
-  .pinCs = SL_SPIDRV_EXP_CS_PIN,
+  .pinCs   = SL_SPIDRV_EXP_CS_PIN,
 #endif
 #else
   .portLocation = SL_SPIDRV_EXP_ROUTE_LOC,
 #endif
-  .bitRate = SL_SPIDRV_EXP_BITRATE,
-  .frameLength = SL_SPIDRV_EXP_FRAME_LENGTH,
-  .dummyTxValue = 0,
-  .type = SL_SPIDRV_EXP_TYPE,
-  .bitOrder = SL_SPIDRV_EXP_BIT_ORDER,
-  .clockMode = SL_SPIDRV_EXP_CLOCK_MODE,
-  .csControl = SL_SPIDRV_EXP_CS_CONTROL,
+  .bitRate        = SL_SPIDRV_EXP_BITRATE,
+  .frameLength    = SL_SPIDRV_EXP_FRAME_LENGTH,
+  .dummyTxValue   = 0,
+  .type           = SL_SPIDRV_EXP_TYPE,
+  .bitOrder       = SL_SPIDRV_EXP_BIT_ORDER,
+  .clockMode      = SL_SPIDRV_EXP_CLOCK_MODE,
+  .csControl      = SL_SPIDRV_EXP_CS_CONTROL,
   .slaveStartMode = SL_SPIDRV_EXP_SLAVE_START_MODE,
 };
 
-void sl_spidrv_init_instances(void) {
-  SPIDRV_Init(sl_spidrv_exp_handle, &sl_spidrv_init_exp); 
+void sl_spidrv_init_instances(void)
+{
+  SPIDRV_Init(sl_spidrv_exp_handle, &sl_spidrv_init_exp);
 }
 
 #endif

--- a/matter/efr32/efr32mg24/BRD4186C/autogen/sl_spidrv_init.c
+++ b/matter/efr32/efr32mg24/BRD4186C/autogen/sl_spidrv_init.c
@@ -3,8 +3,7 @@
 #include "sl_assert.h"
 
 // EUSART is used in MG24 + RS9116 combination
-#ifdef RS911X_WIFI
-#if !(defined(EXP_BOARD) && EXP_BOARD)
+#if defined(RS911X_WIFI) && !defined(EXP_BOARD)
 #include "sl_spidrv_eusart_exp_config.h"
 
 SPIDRV_HandleData_t sl_spidrv_eusart_exp_handle_data;
@@ -41,10 +40,9 @@ void sl_spidrv_init_instances(void)
 #endif
   SPIDRV_Init(sl_spidrv_eusart_exp_handle, &sl_spidrv_eusart_init_exp);
 }
-#endif
-#endif
+#endif //defined(RS911X_WIFI) && !defined(EXP_BOARD)
 
-#if (WF200_WIFI | EXP_BOARD) // USART is used in MG24 + WF200 and MG24 + 917 NCP combination
+#if defined(WF200_WIFI) || defined(EXP_BOARD) // USART is used in MG24 + WF200 and MG24 + 917 NCP combination
 #include "sl_spidrv_exp_config.h"
 
 SPIDRV_HandleData_t sl_spidrv_exp_handle_data;
@@ -90,4 +88,4 @@ void sl_spidrv_init_instances(void)
   SPIDRV_Init(sl_spidrv_exp_handle, &sl_spidrv_init_exp);
 }
 
-#endif
+#endif //defined(WF200_WIFI) || defined(EXP_BOARD)

--- a/matter/efr32/efr32mg24/BRD4186C/autogen/sl_spidrv_instances.h
+++ b/matter/efr32/efr32mg24/BRD4186C/autogen/sl_spidrv_instances.h
@@ -7,15 +7,13 @@ extern "C" {
 
 #include "spidrv.h"
 
-#ifdef RS911X_WIFI
-#if !(defined(EXP_BOARD) && EXP_BOARD)
+#if defined(RS911X_WIFI) && !defined(EXP_BOARD)
 extern SPIDRV_Handle_t sl_spidrv_eusart_exp_handle;
-#endif
-#endif
+#endif //defined(RS911X_WIFI) && !defined(EXP_BOARD)
 
-#if (WF200_WIFI | EXP_BOARD)
+#if defined(WF200_WIFI) || defined(EXP_BOARD)
 extern SPIDRV_Handle_t sl_spidrv_exp_handle;
-#endif
+#endif //defined(WF200_WIFI) || defined(EXP_BOARD)
 
 void sl_spidrv_init_instances(void);
 

--- a/matter/efr32/efr32mg24/BRD4186C/autogen/sl_spidrv_instances.h
+++ b/matter/efr32/efr32mg24/BRD4186C/autogen/sl_spidrv_instances.h
@@ -6,11 +6,14 @@ extern "C" {
 #endif
 
 #include "spidrv.h"
+
 #ifdef RS911X_WIFI
+#if !(defined(EXP_BOARD) && EXP_BOARD)
 extern SPIDRV_Handle_t sl_spidrv_eusart_exp_handle;
 #endif
+#endif
 
-#ifdef WF200_WIFI
+#if (WF200_WIFI | EXP_BOARD)
 extern SPIDRV_Handle_t sl_spidrv_exp_handle;
 #endif
 

--- a/matter/efr32/efr32mg24/BRD4187C/autogen/sl_event_handler.c
+++ b/matter/efr32/efr32mg24/BRD4187C/autogen/sl_event_handler.c
@@ -71,10 +71,8 @@ void sl_kernel_start(void)
 void sl_driver_init(void)
 {
   sl_gpio_init();
-#ifndef SLI_SI917
 #ifdef SL_WIFI
   sl_spidrv_init_instances();
-#endif
 #endif
 #if defined(SL_MATTER_USE_SI70XX_SENSOR) && SL_MATTER_USE_SI70XX_SENSOR
   sl_i2cspm_init_instances();

--- a/matter/efr32/efr32mg24/BRD4187C/autogen/sl_spidrv_init.c
+++ b/matter/efr32/efr32mg24/BRD4187C/autogen/sl_spidrv_init.c
@@ -2,47 +2,49 @@
 #include "sl_spidrv_instances.h"
 #include "sl_assert.h"
 
-
-#ifdef RS911X_WIFI // EUSART is used in MG24 + RS9116 combination
+// EUSART is used in MG24 + RS9116 combination
+#ifdef RS911X_WIFI
+#if !(defined(EXP_BOARD) && EXP_BOARD)
 #include "sl_spidrv_eusart_exp_config.h"
 
 SPIDRV_HandleData_t sl_spidrv_eusart_exp_handle_data;
 SPIDRV_Handle_t sl_spidrv_eusart_exp_handle = &sl_spidrv_eusart_exp_handle_data;
 
 SPIDRV_Init_t sl_spidrv_eusart_init_exp = {
-  .port = SL_SPIDRV_EUSART_EXP_PERIPHERAL,
-  .portTx = SL_SPIDRV_EUSART_EXP_TX_PORT,
-  .portRx = SL_SPIDRV_EUSART_EXP_RX_PORT,
+  .port    = SL_SPIDRV_EUSART_EXP_PERIPHERAL,
+  .portTx  = SL_SPIDRV_EUSART_EXP_TX_PORT,
+  .portRx  = SL_SPIDRV_EUSART_EXP_RX_PORT,
   .portClk = SL_SPIDRV_EUSART_EXP_SCLK_PORT,
 #if defined(SL_SPIDRV_EUSART_EXP_CS_PORT)
   .portCs = SL_SPIDRV_EUSART_EXP_CS_PORT,
 #endif
-  .pinTx = SL_SPIDRV_EUSART_EXP_TX_PIN,
-  .pinRx = SL_SPIDRV_EUSART_EXP_RX_PIN,
+  .pinTx  = SL_SPIDRV_EUSART_EXP_TX_PIN,
+  .pinRx  = SL_SPIDRV_EUSART_EXP_RX_PIN,
   .pinClk = SL_SPIDRV_EUSART_EXP_SCLK_PIN,
 #if defined(SL_SPIDRV_EUSART_EXP_CS_PIN)
   .pinCs = SL_SPIDRV_EUSART_EXP_CS_PIN,
 #endif
-  .bitRate = SL_SPIDRV_EUSART_EXP_BITRATE,
-  .frameLength = SL_SPIDRV_EUSART_EXP_FRAME_LENGTH,
-  .dummyTxValue = 0,
-  .type = SL_SPIDRV_EUSART_EXP_TYPE,
-  .bitOrder = SL_SPIDRV_EUSART_EXP_BIT_ORDER,
-  .clockMode = SL_SPIDRV_EUSART_EXP_CLOCK_MODE,
-  .csControl = SL_SPIDRV_EUSART_EXP_CS_CONTROL,
+  .bitRate        = SL_SPIDRV_EUSART_EXP_BITRATE,
+  .frameLength    = SL_SPIDRV_EUSART_EXP_FRAME_LENGTH,
+  .dummyTxValue   = 0,
+  .type           = SL_SPIDRV_EUSART_EXP_TYPE,
+  .bitOrder       = SL_SPIDRV_EUSART_EXP_BIT_ORDER,
+  .clockMode      = SL_SPIDRV_EUSART_EXP_CLOCK_MODE,
+  .csControl      = SL_SPIDRV_EUSART_EXP_CS_CONTROL,
   .slaveStartMode = SL_SPIDRV_EUSART_EXP_SLAVE_START_MODE,
 };
 
-void sl_spidrv_init_instances(void) {
+void sl_spidrv_init_instances(void)
+{
 #if !defined(SL_SPIDRV_USART_EXP_CS_PIN)
   EFM_ASSERT(sl_spidrv_eusart_init_exp.csControl == spidrvCsControlAuto);
-#endif 
+#endif
   SPIDRV_Init(sl_spidrv_eusart_exp_handle, &sl_spidrv_eusart_init_exp);
 }
-
+#endif
 #endif
 
-#ifdef WF200_WIFI  // USART is used in MG24 + WF200 combination
+#if (WF200_WIFI | EXP_BOARD) // USART is used in MG24 + WF200 and MG24 + 917 NCP combination
 #include "sl_spidrv_exp_config.h"
 
 SPIDRV_HandleData_t sl_spidrv_exp_handle_data;
@@ -51,40 +53,41 @@ SPIDRV_Handle_t sl_spidrv_exp_handle = &sl_spidrv_exp_handle_data;
 SPIDRV_Init_t sl_spidrv_init_exp = {
   .port = SL_SPIDRV_EXP_PERIPHERAL,
 #if defined(_USART_ROUTELOC0_MASK)
-  .portLocationTx = SL_SPIDRV_EXP_TX_LOC,
-  .portLocationRx = SL_SPIDRV_EXP_RX_LOC,
+  .portLocationTx  = SL_SPIDRV_EXP_TX_LOC,
+  .portLocationRx  = SL_SPIDRV_EXP_RX_LOC,
   .portLocationClk = SL_SPIDRV_EXP_CLK_LOC,
 #if defined(SL_SPIDRV_EXP_CS_LOC)
   .portLocationCs = SL_SPIDRV_EXP_CS_LOC,
 #endif
 #elif defined(_GPIO_USART_ROUTEEN_MASK)
-  .portTx = SL_SPIDRV_EXP_TX_PORT,
-  .portRx = SL_SPIDRV_EXP_RX_PORT,
+  .portTx  = SL_SPIDRV_EXP_TX_PORT,
+  .portRx  = SL_SPIDRV_EXP_RX_PORT,
   .portClk = SL_SPIDRV_EXP_CLK_PORT,
 #if defined(SL_SPIDRV_EXP_CS_PORT)
-  .portCs = SL_SPIDRV_EXP_CS_PORT,
+  .portCs  = SL_SPIDRV_EXP_CS_PORT,
 #endif
-  .pinTx = SL_SPIDRV_EXP_TX_PIN,
-  .pinRx = SL_SPIDRV_EXP_RX_PIN,
-  .pinClk = SL_SPIDRV_EXP_CLK_PIN,
+  .pinTx   = SL_SPIDRV_EXP_TX_PIN,
+  .pinRx   = SL_SPIDRV_EXP_RX_PIN,
+  .pinClk  = SL_SPIDRV_EXP_CLK_PIN,
 #if defined(SL_SPIDRV_EXP_CS_PIN)
-  .pinCs = SL_SPIDRV_EXP_CS_PIN,
+  .pinCs   = SL_SPIDRV_EXP_CS_PIN,
 #endif
 #else
   .portLocation = SL_SPIDRV_EXP_ROUTE_LOC,
 #endif
-  .bitRate = SL_SPIDRV_EXP_BITRATE,
-  .frameLength = SL_SPIDRV_EXP_FRAME_LENGTH,
-  .dummyTxValue = 0,
-  .type = SL_SPIDRV_EXP_TYPE,
-  .bitOrder = SL_SPIDRV_EXP_BIT_ORDER,
-  .clockMode = SL_SPIDRV_EXP_CLOCK_MODE,
-  .csControl = SL_SPIDRV_EXP_CS_CONTROL,
+  .bitRate        = SL_SPIDRV_EXP_BITRATE,
+  .frameLength    = SL_SPIDRV_EXP_FRAME_LENGTH,
+  .dummyTxValue   = 0,
+  .type           = SL_SPIDRV_EXP_TYPE,
+  .bitOrder       = SL_SPIDRV_EXP_BIT_ORDER,
+  .clockMode      = SL_SPIDRV_EXP_CLOCK_MODE,
+  .csControl      = SL_SPIDRV_EXP_CS_CONTROL,
   .slaveStartMode = SL_SPIDRV_EXP_SLAVE_START_MODE,
 };
 
-void sl_spidrv_init_instances(void) {
-  SPIDRV_Init(sl_spidrv_exp_handle, &sl_spidrv_init_exp); 
+void sl_spidrv_init_instances(void)
+{
+  SPIDRV_Init(sl_spidrv_exp_handle, &sl_spidrv_init_exp);
 }
 
 #endif

--- a/matter/efr32/efr32mg24/BRD4187C/autogen/sl_spidrv_init.c
+++ b/matter/efr32/efr32mg24/BRD4187C/autogen/sl_spidrv_init.c
@@ -3,8 +3,7 @@
 #include "sl_assert.h"
 
 // EUSART is used in MG24 + RS9116 combination
-#ifdef RS911X_WIFI
-#if !(defined(EXP_BOARD) && EXP_BOARD)
+#if defined(RS911X_WIFI) && !defined(EXP_BOARD)
 #include "sl_spidrv_eusart_exp_config.h"
 
 SPIDRV_HandleData_t sl_spidrv_eusart_exp_handle_data;
@@ -41,10 +40,9 @@ void sl_spidrv_init_instances(void)
 #endif
   SPIDRV_Init(sl_spidrv_eusart_exp_handle, &sl_spidrv_eusart_init_exp);
 }
-#endif
-#endif
+#endif //defined(RS911X_WIFI) && !defined(EXP_BOARD)
 
-#if (WF200_WIFI | EXP_BOARD) // USART is used in MG24 + WF200 and MG24 + 917 NCP combination
+#if defined(WF200_WIFI) || defined(EXP_BOARD) // USART is used in MG24 + WF200 and MG24 + 917 NCP combination
 #include "sl_spidrv_exp_config.h"
 
 SPIDRV_HandleData_t sl_spidrv_exp_handle_data;
@@ -90,4 +88,4 @@ void sl_spidrv_init_instances(void)
   SPIDRV_Init(sl_spidrv_exp_handle, &sl_spidrv_init_exp);
 }
 
-#endif
+#endif //defined(WF200_WIFI) || defined(EXP_BOARD)

--- a/matter/efr32/efr32mg24/BRD4187C/autogen/sl_spidrv_instances.h
+++ b/matter/efr32/efr32mg24/BRD4187C/autogen/sl_spidrv_instances.h
@@ -7,15 +7,13 @@ extern "C" {
 
 #include "spidrv.h"
 
-#ifdef RS911X_WIFI
-#if !(defined(EXP_BOARD) && EXP_BOARD)
+#if defined(RS911X_WIFI) && !defined(EXP_BOARD)
 extern SPIDRV_Handle_t sl_spidrv_eusart_exp_handle;
-#endif
-#endif
+#endif //defined(RS911X_WIFI) && !defined(EXP_BOARD)
 
-#if (WF200_WIFI | EXP_BOARD)
+#if defined(WF200_WIFI) || defined(EXP_BOARD)
 extern SPIDRV_Handle_t sl_spidrv_exp_handle;
-#endif
+#endif //defined(WF200_WIFI) || defined(EXP_BOARD)
 
 void sl_spidrv_init_instances(void);
 

--- a/matter/efr32/efr32mg24/BRD4187C/autogen/sl_spidrv_instances.h
+++ b/matter/efr32/efr32mg24/BRD4187C/autogen/sl_spidrv_instances.h
@@ -6,11 +6,14 @@ extern "C" {
 #endif
 
 #include "spidrv.h"
+
 #ifdef RS911X_WIFI
+#if !(defined(EXP_BOARD) && EXP_BOARD)
 extern SPIDRV_Handle_t sl_spidrv_eusart_exp_handle;
 #endif
+#endif
 
-#ifdef WF200_WIFI
+#if (WF200_WIFI | EXP_BOARD)
 extern SPIDRV_Handle_t sl_spidrv_exp_handle;
 #endif
 


### PR DESCRIPTION
#### Problem / Feature
 917 ncp autogen files updated as USART is used for SPI based on wifi sdk 3.4.0.

#### Change overview
slc generate for EFR32 mg24 and 917 ncp autogen files and edited the files according to the USART.

#### Testing
Verified builds app for EFR32 mg24 and 917 NCP board.
and commission test.
