### PR TITLE
Fixing the button IRQ state with the wifi sdk v3.4.1

### DIFF
--- a/matter/si91x/support/hal/rsi_hal_mcu_m4.c
+++ b/matter/si91x/support/hal/rsi_hal_mcu_m4.c
@@ -84,7 +84,7 @@ int soc_pll_config(void) {
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 void sl_si91x_button_isr(uint8_t pin, int8_t state) {
   (pin == SL_BUTTON_BTN0_PIN)
-      ? sl_button_on_change(SL_BUTTON_BTN0_NUMBER, !state)
-      : sl_button_on_change(SL_BUTTON_BTN1_NUMBER, !state);
+      ? sl_button_on_change(SL_BUTTON_BTN0_NUMBER, state)
+      : sl_button_on_change(SL_BUTTON_BTN1_NUMBER, state);
 }
 #endif  //SL_CATALOG_SIMPLE_BUTTON_PRESENT


### PR DESCRIPTION
#### Problem / Feature
With the wifi sdk v3.4.1-rc2, the btn irq handled is modified hence the state changes are now correct

#### Change overview
Changing the button handling and passing the correct parameter
Pressed -> 1
Release -> 0

#### Testing
Tested locally


Note: This will break the CSA if this pointer is added, since it fixes the v3.4.1-rc2 and CSA is on v3.4.0 only